### PR TITLE
[#3] 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,38 +1,42 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.1'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.1'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.hyun'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'org.postgresql:postgresql'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hyun/udong/UdongApplication.java
+++ b/src/main/java/com/hyun/udong/UdongApplication.java
@@ -2,12 +2,13 @@ package com.hyun.udong;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class UdongApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(UdongApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(UdongApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
+++ b/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
@@ -18,7 +18,7 @@ public class AuthService {
     public AccessTokenResponse kakaoLogin(String code) {
         KakaoTokenResponse kakaoTokenResponse = kakaoOAuthClient.getToken(code);
         KakaoProfileResponse profile = kakaoOAuthClient.getUserProfile(kakaoTokenResponse.getAccessToken());
-        memberService.saveOrUpdate(profile.toMember());
+        memberService.save(profile.toMember());
         return new AccessTokenResponse(kakaoTokenResponse.getIdToken(), kakaoTokenResponse.getExpiresIn());
     }
 }

--- a/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
+++ b/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
@@ -1,0 +1,24 @@
+package com.hyun.udong.auth.application.service;
+
+import com.hyun.udong.auth.infrastructure.client.KakaoOAuthClient;
+import com.hyun.udong.auth.presentation.dto.AccessTokenResponse;
+import com.hyun.udong.auth.presentation.dto.KakaoProfileResponse;
+import com.hyun.udong.auth.presentation.dto.KakaoTokenResponse;
+import com.hyun.udong.member.application.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final MemberService memberService;
+
+    public AccessTokenResponse kakaoLogin(String code) {
+        KakaoTokenResponse kakaoTokenResponse = kakaoOAuthClient.getToken(code);
+        KakaoProfileResponse profile = kakaoOAuthClient.getUserProfile(kakaoTokenResponse.getAccessToken());
+        memberService.saveOrUpdate(profile.toMember());
+        return new AccessTokenResponse(kakaoTokenResponse.getIdToken(), kakaoTokenResponse.getExpiresIn());
+    }
+}

--- a/src/main/java/com/hyun/udong/auth/infrastructure/client/KakaoOAuthClient.java
+++ b/src/main/java/com/hyun/udong/auth/infrastructure/client/KakaoOAuthClient.java
@@ -1,0 +1,63 @@
+package com.hyun.udong.auth.infrastructure.client;
+
+import com.hyun.udong.auth.presentation.dto.KakaoProfileResponse;
+import com.hyun.udong.auth.presentation.dto.KakaoTokenResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class KakaoOAuthClient {
+
+    private static final String ACCESS_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String USER_PROFILE_URL = "https://kapi.kakao.com/v2/user/me";
+
+    @Value("${social.kakao.client-id}")
+    private String clientId;
+
+    @Value("${social.kakao.redirect-uri}")
+    private String redirectUri;
+
+    public KakaoProfileResponse getUserProfile(String accessToken) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        ResponseEntity<KakaoProfileResponse> response = restTemplate.exchange(
+            USER_PROFILE_URL, HttpMethod.GET, request, KakaoProfileResponse.class
+        );
+
+        return response.getBody();
+    }
+
+    public KakaoTokenResponse getToken(String code) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
+            ACCESS_TOKEN_URL, HttpMethod.POST, request, KakaoTokenResponse.class
+        );
+
+        return response.getBody();
+    }
+}

--- a/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
@@ -1,0 +1,30 @@
+package com.hyun.udong.auth.presentation.controller;
+
+import com.hyun.udong.auth.infrastructure.client.KakaoOAuthClient;
+import com.hyun.udong.auth.presentation.dto.AccessTokenResponse;
+import com.hyun.udong.auth.presentation.dto.KakaoProfileResponse;
+import com.hyun.udong.auth.presentation.dto.KakaoTokenResponse;
+import com.hyun.udong.member.application.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final MemberService memberService;
+
+    @GetMapping("/login/kakao")
+    public ResponseEntity<AccessTokenResponse> kakaoLogin(@RequestParam("code") final String code) {
+        KakaoTokenResponse kakaoTokenResponse = kakaoOAuthClient.getToken(code);
+        KakaoProfileResponse profile = kakaoOAuthClient.getUserProfile(kakaoTokenResponse.getAccessToken());
+        memberService.saveOrUpdate(profile.toMember());
+        return ResponseEntity.ok().body(new AccessTokenResponse(kakaoTokenResponse.getIdToken(), kakaoTokenResponse.getExpiresIn()));
+    }
+}

--- a/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
@@ -1,10 +1,7 @@
 package com.hyun.udong.auth.presentation.controller;
 
-import com.hyun.udong.auth.infrastructure.client.KakaoOAuthClient;
+import com.hyun.udong.auth.application.service.AuthService;
 import com.hyun.udong.auth.presentation.dto.AccessTokenResponse;
-import com.hyun.udong.auth.presentation.dto.KakaoProfileResponse;
-import com.hyun.udong.auth.presentation.dto.KakaoTokenResponse;
-import com.hyun.udong.member.application.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,14 +14,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/auth")
 public class AuthController {
 
-    private final KakaoOAuthClient kakaoOAuthClient;
-    private final MemberService memberService;
+    private final AuthService authService;
+
 
     @GetMapping("/login/kakao")
     public ResponseEntity<AccessTokenResponse> kakaoLogin(@RequestParam("code") final String code) {
-        KakaoTokenResponse kakaoTokenResponse = kakaoOAuthClient.getToken(code);
-        KakaoProfileResponse profile = kakaoOAuthClient.getUserProfile(kakaoTokenResponse.getAccessToken());
-        memberService.saveOrUpdate(profile.toMember());
-        return ResponseEntity.ok().body(new AccessTokenResponse(kakaoTokenResponse.getIdToken(), kakaoTokenResponse.getExpiresIn()));
+        AccessTokenResponse accessToken = authService.kakaoLogin(code);
+        return ResponseEntity.ok().body(accessToken);
     }
 }

--- a/src/main/java/com/hyun/udong/auth/presentation/dto/AccessTokenResponse.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/dto/AccessTokenResponse.java
@@ -1,19 +1,4 @@
 package com.hyun.udong.auth.presentation.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@AllArgsConstructor
-@Getter
-public class AccessTokenResponse {
-    private final String accessToken;
-    private final long expiredTime;
-
-    public String getAccessToken() {
-        return accessToken;
-    }
-
-    public long getExpiredTime() {
-        return expiredTime;
-    }
+public record AccessTokenResponse(String accessToken, long expiredTime) {
 }

--- a/src/main/java/com/hyun/udong/auth/presentation/dto/AccessTokenResponse.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/dto/AccessTokenResponse.java
@@ -1,0 +1,19 @@
+package com.hyun.udong.auth.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class AccessTokenResponse {
+    private final String accessToken;
+    private final long expiredTime;
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public long getExpiredTime() {
+        return expiredTime;
+    }
+}

--- a/src/main/java/com/hyun/udong/auth/presentation/dto/KakaoProfileResponse.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/dto/KakaoProfileResponse.java
@@ -1,0 +1,38 @@
+package com.hyun.udong.auth.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hyun.udong.member.domain.Member;
+import com.hyun.udong.member.domain.SocialType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoProfileResponse {
+
+    //회원 번호
+    @JsonProperty("id")
+    private Long id;
+
+    private String nickname;
+
+    private String profileImageUrl;
+
+    @SuppressWarnings("unchecked")
+    @JsonProperty("kakao_account")
+    private void unpackNested(Map<String, Object> kakaoAccount) {
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        this.nickname = (String) profile.get("nickname");
+        this.profileImageUrl = (String) profile.get("profile_image_url");
+    }
+
+    public Member toMember() {
+        return new Member(id, SocialType.KAKAO, getNickname(), getProfileImageUrl());
+    }
+}

--- a/src/main/java/com/hyun/udong/auth/presentation/dto/KakaoProfileResponse.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/dto/KakaoProfileResponse.java
@@ -1,38 +1,49 @@
 package com.hyun.udong.auth.presentation.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hyun.udong.member.domain.Member;
 import com.hyun.udong.member.domain.SocialType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Map;
-
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class KakaoProfileResponse {
 
-    //회원 번호
-    @JsonProperty("id")
     private Long id;
 
-    private String nickname;
+    private KakaoAccount kakaoAccount;
 
-    private String profileImageUrl;
+    @Getter
+    public static class KakaoAccount {
 
-    @SuppressWarnings("unchecked")
-    @JsonProperty("kakao_account")
-    private void unpackNested(Map<String, Object> kakaoAccount) {
-        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
-        this.nickname = (String) profile.get("nickname");
-        this.profileImageUrl = (String) profile.get("profile_image_url");
+        private Profile profile;
+
+        @Getter
+        @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+        private static class Profile {
+
+            private String nickname;
+            private String profileImageUrl;
+        }
+
+        public String getNickname() {
+            return profile.getNickname();
+        }
+
+        public String getProfileImageUrl() {
+            return profile.getProfileImageUrl();
+        }
     }
 
     public Member toMember() {
-        return new Member(id, SocialType.KAKAO, getNickname(), getProfileImageUrl());
+        KakaoAccount account = getKakaoAccount();
+        return new Member(id, SocialType.KAKAO, account.getNickname(), account.getProfileImageUrl());
     }
 }

--- a/src/main/java/com/hyun/udong/auth/presentation/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/dto/KakaoTokenResponse.java
@@ -1,0 +1,33 @@
+package com.hyun.udong.auth.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoTokenResponse {
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("id_token")
+    private String idToken;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    private Integer refreshTokenExpiresIn;
+
+    private String scope;
+}

--- a/src/main/java/com/hyun/udong/auth/presentation/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/dto/KakaoTokenResponse.java
@@ -1,7 +1,8 @@
 package com.hyun.udong.auth.presentation.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,24 +10,19 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class KakaoTokenResponse {
 
-    @JsonProperty("token_type")
     private String tokenType;
 
-    @JsonProperty("access_token")
     private String accessToken;
 
-    @JsonProperty("id_token")
     private String idToken;
 
-    @JsonProperty("expires_in")
     private Integer expiresIn;
 
-    @JsonProperty("refresh_token")
     private String refreshToken;
 
-    @JsonProperty("refresh_token_expires_in")
     private Integer refreshTokenExpiresIn;
 
     private String scope;

--- a/src/main/java/com/hyun/udong/member/application/service/MemberService.java
+++ b/src/main/java/com/hyun/udong/member/application/service/MemberService.java
@@ -21,9 +21,11 @@ public class MemberService {
         Optional<Member> foundMember = memberRepository.findBySocialIdAndSocialType(member.getSocialId(), member.getSocialType());
 
         if (foundMember.isPresent()) {
-            foundMember.get().update(member.getNickname(), member.getProfileImageUrl());
+            Member updatedMember = foundMember.get()
+                    .withNickname(member.getNickname())
+                    .withProfileImageUrl(member.getProfileImageUrl());
 
-            return new MemberResponse(foundMember.get());
+            return new MemberResponse(memberRepository.save(updatedMember));
         }
 
         return new MemberResponse(memberRepository.save(member));

--- a/src/main/java/com/hyun/udong/member/application/service/MemberService.java
+++ b/src/main/java/com/hyun/udong/member/application/service/MemberService.java
@@ -17,7 +17,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public MemberResponse saveOrUpdate(Member member) {
+    public MemberResponse save(Member member) {
         Optional<Member> foundMember = memberRepository.findBySocialIdAndSocialType(member.getSocialId(), member.getSocialType());
 
         if (foundMember.isPresent()) {

--- a/src/main/java/com/hyun/udong/member/application/service/MemberService.java
+++ b/src/main/java/com/hyun/udong/member/application/service/MemberService.java
@@ -21,11 +21,9 @@ public class MemberService {
         Optional<Member> foundMember = memberRepository.findBySocialIdAndSocialType(member.getSocialId(), member.getSocialType());
 
         if (foundMember.isPresent()) {
-            Member updatedMember = foundMember.get()
-                    .withNickname(member.getNickname())
-                    .withProfileImageUrl(member.getProfileImageUrl());
+            foundMember.get().updateProfile(member.getNickname(), member.getProfileImageUrl());
 
-            return MemberResponse.fromMember(memberRepository.save(updatedMember));
+            return MemberResponse.fromMember(foundMember.get());
         }
 
         return MemberResponse.fromMember(memberRepository.save(member));

--- a/src/main/java/com/hyun/udong/member/application/service/MemberService.java
+++ b/src/main/java/com/hyun/udong/member/application/service/MemberService.java
@@ -1,0 +1,37 @@
+package com.hyun.udong.member.application.service;
+
+import com.hyun.udong.member.domain.Member;
+import com.hyun.udong.member.infrastructure.repository.MemberRepository;
+import com.hyun.udong.member.presentation.dto.MemberResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public MemberResponse saveOrUpdate(Member member) {
+        Optional<Member> foundMember = memberRepository.findBySocialIdAndSocialType(member.getSocialId(), member.getSocialType());
+
+        if (foundMember.isPresent()) {
+            foundMember.get().update(member.getNickname(), member.getProfileImageUrl());
+
+            return new MemberResponse(foundMember.get());
+        }
+
+        return new MemberResponse(memberRepository.save(member));
+    }
+
+    public MemberResponse getMemberById(Long id) {
+        Member member = memberRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당하는 회원이 없습니다."));
+
+        return new MemberResponse(member);
+    }
+}

--- a/src/main/java/com/hyun/udong/member/application/service/MemberService.java
+++ b/src/main/java/com/hyun/udong/member/application/service/MemberService.java
@@ -25,15 +25,15 @@ public class MemberService {
                     .withNickname(member.getNickname())
                     .withProfileImageUrl(member.getProfileImageUrl());
 
-            return new MemberResponse(memberRepository.save(updatedMember));
+            return MemberResponse.fromMember(memberRepository.save(updatedMember));
         }
 
-        return new MemberResponse(memberRepository.save(member));
+        return MemberResponse.fromMember(memberRepository.save(member));
     }
 
     public MemberResponse getMemberById(Long id) {
         Member member = memberRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당하는 회원이 없습니다."));
 
-        return new MemberResponse(member);
+        return MemberResponse.fromMember(member);
     }
 }

--- a/src/main/java/com/hyun/udong/member/application/service/MemberService.java
+++ b/src/main/java/com/hyun/udong/member/application/service/MemberService.java
@@ -23,15 +23,15 @@ public class MemberService {
         if (foundMember.isPresent()) {
             foundMember.get().updateProfile(member.getNickname(), member.getProfileImageUrl());
 
-            return MemberResponse.fromMember(foundMember.get());
+            return MemberResponse.from(foundMember.get());
         }
 
-        return MemberResponse.fromMember(memberRepository.save(member));
+        return MemberResponse.from(memberRepository.save(member));
     }
 
     public MemberResponse getMemberById(Long id) {
         Member member = memberRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당하는 회원이 없습니다."));
 
-        return MemberResponse.fromMember(member);
+        return MemberResponse.from(member);
     }
 }

--- a/src/main/java/com/hyun/udong/member/domain/Member.java
+++ b/src/main/java/com/hyun/udong/member/domain/Member.java
@@ -1,0 +1,42 @@
+package com.hyun.udong.member.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long socialId;
+
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType;
+
+    private String nickname;
+
+    private String gender;
+
+    private int age;
+
+    private String profileImageUrl;
+
+    public Member(Long socialId, SocialType socialType, String nickname, String profileImageUrl) {
+        this.socialId = socialId;
+        this.socialType = socialType;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void update(String nickname, String profileImageUrl) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/src/main/java/com/hyun/udong/member/domain/Member.java
+++ b/src/main/java/com/hyun/udong/member/domain/Member.java
@@ -1,17 +1,14 @@
 package com.hyun.udong.member.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.With;
 
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-@AllArgsConstructor
 public class Member {
 
     @Id
@@ -23,19 +20,22 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private SocialType socialType;
 
-    @With
     private String nickname;
 
     private String gender;
 
     private int age;
 
-    @With
     private String profileImageUrl;
 
     public Member(Long socialId, SocialType socialType, String nickname, String profileImageUrl) {
         this.socialId = socialId;
         this.socialType = socialType;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void updateProfile(String nickname, String profileImageUrl) {
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
     }

--- a/src/main/java/com/hyun/udong/member/domain/Member.java
+++ b/src/main/java/com/hyun/udong/member/domain/Member.java
@@ -1,14 +1,17 @@
 package com.hyun.udong.member.domain;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.With;
 
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
 public class Member {
 
     @Id
@@ -20,22 +23,19 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private SocialType socialType;
 
+    @With
     private String nickname;
 
     private String gender;
 
     private int age;
 
+    @With
     private String profileImageUrl;
 
     public Member(Long socialId, SocialType socialType, String nickname, String profileImageUrl) {
         this.socialId = socialId;
         this.socialType = socialType;
-        this.nickname = nickname;
-        this.profileImageUrl = profileImageUrl;
-    }
-
-    public void update(String nickname, String profileImageUrl) {
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
     }

--- a/src/main/java/com/hyun/udong/member/domain/SocialType.java
+++ b/src/main/java/com/hyun/udong/member/domain/SocialType.java
@@ -1,0 +1,5 @@
+package com.hyun.udong.member.domain;
+
+public enum SocialType {
+    KAKAO, GOOGLE
+}

--- a/src/main/java/com/hyun/udong/member/infrastructure/repository/MemberRepository.java
+++ b/src/main/java/com/hyun/udong/member/infrastructure/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.hyun.udong.member.infrastructure.repository;
+
+import com.hyun.udong.member.domain.Member;
+import com.hyun.udong.member.domain.SocialType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findBySocialIdAndSocialType(Long socialId, SocialType socialType);
+}
+

--- a/src/main/java/com/hyun/udong/member/presentation/dto/MemberResponse.java
+++ b/src/main/java/com/hyun/udong/member/presentation/dto/MemberResponse.java
@@ -13,7 +13,7 @@ public class MemberResponse {
     private int age;
     private String profileImageUrl;
 
-    public MemberResponse(Member member) {
-        this(member.getId(), member.getNickname(), member.getGender(), member.getAge(), member.getProfileImageUrl());
+    public static MemberResponse fromMember(Member member) {
+        return new MemberResponse(member.getId(), member.getNickname(), member.getGender(), member.getAge(), member.getProfileImageUrl());
     }
 }

--- a/src/main/java/com/hyun/udong/member/presentation/dto/MemberResponse.java
+++ b/src/main/java/com/hyun/udong/member/presentation/dto/MemberResponse.java
@@ -1,0 +1,19 @@
+package com.hyun.udong.member.presentation.dto;
+
+import com.hyun.udong.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class MemberResponse {
+    private Long id;
+    private String nickname;
+    private String gender;
+    private int age;
+    private String profileImageUrl;
+
+    public MemberResponse(Member member) {
+        this(member.getId(), member.getNickname(), member.getGender(), member.getAge(), member.getProfileImageUrl());
+    }
+}

--- a/src/main/java/com/hyun/udong/member/presentation/dto/MemberResponse.java
+++ b/src/main/java/com/hyun/udong/member/presentation/dto/MemberResponse.java
@@ -13,7 +13,7 @@ public class MemberResponse {
     private int age;
     private String profileImageUrl;
 
-    public static MemberResponse fromMember(Member member) {
+    public static MemberResponse from(Member member) {
         return new MemberResponse(member.getId(), member.getNickname(), member.getGender(), member.getAge(), member.getProfileImageUrl());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,0 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/hyn
-spring.datasource.username=myuser
-spring.datasource.password=1234
-spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
-spring.application.name=udong

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,25 @@
+spring:
+  datasource:
+    url: ${DATASOURCE_URL}
+    username: ${DATASOURCE_USERNAME}
+    password: ${DATASOURCE_PASSWORD}
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+  application:
+    name: udong
+  mvc:
+    view:
+      prefix: /templates/
+      suffix: .html
+
+social:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
+  google:
+    client-id: ${GOOGLE_CLIENT_ID}
+    client-secret: ${GOOGLE_CLIENT_SECRET}
+    redirect-uri: ${GOOGLE_REDIRECT_URI}

--- a/src/test/java/com/hyun/udong/member/application/service/MemberServiceTest.java
+++ b/src/test/java/com/hyun/udong/member/application/service/MemberServiceTest.java
@@ -1,0 +1,58 @@
+package com.hyun.udong.member.application.service;
+
+import com.hyun.udong.member.domain.Member;
+import com.hyun.udong.member.domain.SocialType;
+import com.hyun.udong.member.presentation.dto.MemberResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @BeforeEach
+    void setUp() {
+        memberService.saveOrUpdate(new Member(1L, SocialType.KAKAO, "짱구", "https://user1.com"));
+        memberService.saveOrUpdate(new Member(2L, SocialType.KAKAO, "짱아", "https://user2.com"));
+    }
+
+    @Test
+    @DisplayName("신규 사용자일 경우 사용자 정보를 저장한다.")
+    void saveMember() {
+        Member member = new Member(3L, SocialType.KAKAO, "신영만", "https://user3.com");
+
+        MemberResponse savedMember = memberService.saveOrUpdate(member);
+
+        MemberResponse findMember = memberService.getMemberById(savedMember.getId());
+        assertAll(
+                () -> assertThat(findMember.getId()).isEqualTo(savedMember.getId()),
+                () -> assertThat(findMember.getNickname()).isEqualTo("신영만"),
+                () -> assertThat(findMember.getProfileImageUrl()).isEqualTo("https://user3.com")
+        );
+    }
+
+    @Test
+    @DisplayName("기존 사용자일 경우 사용자 정보를 수정한다.")
+    void updateMember() {
+        Member member = new Member(2L, SocialType.KAKAO, "짱아아", "https://user2.com");
+
+        MemberResponse updatedMember = memberService.saveOrUpdate(member);
+
+        MemberResponse findMember = memberService.getMemberById(updatedMember.getId());
+        assertAll(
+                () -> assertThat(findMember.getId()).isEqualTo(updatedMember.getId()),
+                () -> assertThat(findMember.getNickname()).isEqualTo("짱아아"),
+                () -> assertThat(findMember.getProfileImageUrl()).isEqualTo("https://user2.com")
+        );
+    }
+}

--- a/src/test/java/com/hyun/udong/member/application/service/MemberServiceTest.java
+++ b/src/test/java/com/hyun/udong/member/application/service/MemberServiceTest.java
@@ -22,8 +22,8 @@ class MemberServiceTest {
 
     @BeforeEach
     void setUp() {
-        memberService.saveOrUpdate(new Member(1L, SocialType.KAKAO, "짱구", "https://user1.com"));
-        memberService.saveOrUpdate(new Member(2L, SocialType.KAKAO, "짱아", "https://user2.com"));
+        memberService.save(new Member(1L, SocialType.KAKAO, "짱구", "https://user1.com"));
+        memberService.save(new Member(2L, SocialType.KAKAO, "짱아", "https://user2.com"));
     }
 
     @Test
@@ -31,7 +31,7 @@ class MemberServiceTest {
     void saveMember() {
         Member member = new Member(3L, SocialType.KAKAO, "신영만", "https://user3.com");
 
-        MemberResponse savedMember = memberService.saveOrUpdate(member);
+        MemberResponse savedMember = memberService.save(member);
 
         MemberResponse findMember = memberService.getMemberById(savedMember.getId());
         assertAll(
@@ -46,7 +46,7 @@ class MemberServiceTest {
     void updateMember() {
         Member member = new Member(2L, SocialType.KAKAO, "짱아아", "https://user2.com");
 
-        MemberResponse updatedMember = memberService.saveOrUpdate(member);
+        MemberResponse updatedMember = memberService.save(member);
 
         MemberResponse findMember = memberService.getMemberById(updatedMember.getId());
         assertAll(

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,20 +2,13 @@ spring:
   config:
     import: optional:file:.env[.properties]
   datasource:
-    url: ${DATASOURCE_URL}
-    username: ${DATASOURCE_USERNAME}
-    password: ${DATASOURCE_PASSWORD}
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
   jpa:
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
     show-sql: true
-  application:
-    name: udong
-  mvc:
-    view:
-      prefix: /templates/
-      suffix: .html
 
 social:
   kakao:


### PR DESCRIPTION
## #️⃣ Issue
- #3 

## 🧑🏻‍🏫 메인 리뷰어 지정
- 메인 리뷰어 : @blue000927

## 📝 요약
회원 도메인을 추가하고 카카오 로그인을 구현했습니다.

## 🛠 작업 내용
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1. Member 도메인을 추가하고 회원가입&정보 수정 로직을 추가했습니다.
2. 서비스 차원에서 자체 회원가입을 구현해 관리하기 보다는 OAuth2.0&JWT을 사용해 카카오 로그인을 구현했습니다.
3. 서비스에서 세션 대신 사용할 accessToken을 카카오에서 같이 제공해주어(`idToken`) 따로 JWT토큰을 발급하지 않았습니다.

## References
<!--- 사용된 레퍼런스에 대한 링크를 남겨주세요. -->
- [스프링 부트 프로젝트에서 dotenv 환경변수 파일 사용하기](https://gengminy.tistory.com/24)
- [REST API 카카오 로그인 구현하기](https://ddonghyeo.tistory.com/16#1-1.%20%EB%A1%9C%EA%B7%B8%EC%9D%B8%20%ED%8E%98%EC%9D%B4%EC%A7%80%20%EB%A7%8C%EB%93%A4%EA%B8%B0-1)
- [중첩된 JSON을 Java Object 로 매핑하는 방법1 ](https://velog.io/@chlwogur2/%EC%A4%91%EC%B2%A9%EB%90%9C-JSON%EC%9D%84-Java-Object-%EB%A1%9C-%EB%A7%A4%ED%95%91%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95-With-Jackson)
- [외부 API 를 의존하는 OAuth 로그인 테스트하기](https://velog.io/@tjddus0302/%EC%99%B8%EB%B6%80-API-%EB%A5%BC-%EC%9D%98%EC%A1%B4%ED%95%98%EB%8A%94-OAuth-%ED%85%8C%EC%8A%A4%ED%8A%B8%ED%95%98%EA%B8%B0)

## 🤔 리뷰 시 참고 사항
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
1. 외부 API 테스트 코드는 모킹을 공부한 후에 작성하겠습니다!
2. `AuthController`에서 `MemberService`를 바로 호출하는 게 맞을까요?
3. `memberService`의 `saveOrUpdate`를 `save`, `update` 2가지 책임으로 분리하는 게 적절할까요?
<img src="https://github.com/user-attachments/assets/9baaefce-dc87-4a28-ac35-19e109347216" alt="kakao_login excalidraw" width="500" height="300"/>


## ✅ 체크리스트
- [X] PR 제목을 명령형으로 작성했습니다.
- [X] PR을 연관되는 github issue에 연결했습니다.
- [X] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [X] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트 코드가 필요없는 이유가 있습니다.