### PR TITLE
[#5] refresh_token 저장 및 토큰 갱신 

### DIFF
--- a/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
+++ b/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
@@ -23,7 +23,9 @@ public class AuthService {
     public AccessTokenResponse kakaoLogin(String code) {
         KakaoTokenResponse kakaoTokenResponse = kakaoOAuthClient.getToken(code);
         KakaoProfileResponse profile = kakaoOAuthClient.getUserProfile(kakaoTokenResponse.getAccessToken());
-        memberService.save(profile.toMember());
+        Member member = profile.toMember();
+        member.updateRefreshToken(kakaoTokenResponse.getRefreshToken());
+        memberService.save(member);
         return new AccessTokenResponse(kakaoTokenResponse.getIdToken(), kakaoTokenResponse.getExpiresIn(), kakaoTokenResponse.getRefreshToken());
     }
 

--- a/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
+++ b/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
@@ -5,6 +5,7 @@ import com.hyun.udong.auth.presentation.dto.AccessTokenResponse;
 import com.hyun.udong.auth.presentation.dto.KakaoProfileResponse;
 import com.hyun.udong.auth.presentation.dto.KakaoTokenResponse;
 import com.hyun.udong.member.application.service.MemberService;
+import com.hyun.udong.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -23,6 +24,15 @@ public class AuthService {
         KakaoTokenResponse kakaoTokenResponse = kakaoOAuthClient.getToken(code);
         KakaoProfileResponse profile = kakaoOAuthClient.getUserProfile(kakaoTokenResponse.getAccessToken());
         memberService.save(profile.toMember());
-        return new AccessTokenResponse(kakaoTokenResponse.getIdToken(), kakaoTokenResponse.getExpiresIn());
+        return new AccessTokenResponse(kakaoTokenResponse.getIdToken(), kakaoTokenResponse.getExpiresIn(), kakaoTokenResponse.getRefreshToken());
+    }
+
+    public AccessTokenResponse refreshTokens(String refreshToken) {
+        KakaoTokenResponse kakaoTokenResponse = kakaoOAuthClient.refreshTokens(refreshToken);
+        if (kakaoTokenResponse.getRefreshToken() != null) {
+            Member member = memberService.findByRefreshToken(refreshToken);
+            member.updateRefreshToken(kakaoTokenResponse.getRefreshToken());
+        }
+        return new AccessTokenResponse(kakaoTokenResponse.getIdToken(), kakaoTokenResponse.getExpiresIn(), refreshToken);
     }
 }

--- a/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
+++ b/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
@@ -15,6 +15,10 @@ public class AuthService {
     private final KakaoOAuthClient kakaoOAuthClient;
     private final MemberService memberService;
 
+    public String getOAuthUrl() {
+        return kakaoOAuthClient.getOAuthUrl();
+    }
+
     public AccessTokenResponse kakaoLogin(String code) {
         KakaoTokenResponse kakaoTokenResponse = kakaoOAuthClient.getToken(code);
         KakaoProfileResponse profile = kakaoOAuthClient.getUserProfile(kakaoTokenResponse.getAccessToken());

--- a/src/main/java/com/hyun/udong/auth/infrastructure/client/KakaoOAuthClient.java
+++ b/src/main/java/com/hyun/udong/auth/infrastructure/client/KakaoOAuthClient.java
@@ -3,11 +3,7 @@ package com.hyun.udong.auth.infrastructure.client;
 import com.hyun.udong.auth.presentation.dto.KakaoProfileResponse;
 import com.hyun.udong.auth.presentation.dto.KakaoTokenResponse;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -16,6 +12,7 @@ import org.springframework.web.client.RestTemplate;
 @Component
 public class KakaoOAuthClient {
 
+    private static final String AUTHORIZE_URL = "https://kauth.kakao.com/oauth/authorize?client_id=";
     private static final String ACCESS_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
     private static final String USER_PROFILE_URL = "https://kapi.kakao.com/v2/user/me";
 
@@ -24,6 +21,10 @@ public class KakaoOAuthClient {
 
     @Value("${social.kakao.redirect-uri}")
     private String redirectUri;
+
+    public String getOAuthUrl() {
+        return AUTHORIZE_URL + clientId + "&redirect_uri=" + redirectUri + "&response_type=code";
+    }
 
     public KakaoProfileResponse getUserProfile(String accessToken) {
         RestTemplate restTemplate = new RestTemplate();
@@ -34,7 +35,7 @@ public class KakaoOAuthClient {
 
         HttpEntity<Void> request = new HttpEntity<>(headers);
         ResponseEntity<KakaoProfileResponse> response = restTemplate.exchange(
-            USER_PROFILE_URL, HttpMethod.GET, request, KakaoProfileResponse.class
+                USER_PROFILE_URL, HttpMethod.GET, request, KakaoProfileResponse.class
         );
 
         return response.getBody();
@@ -55,7 +56,7 @@ public class KakaoOAuthClient {
 
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
         ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
-            ACCESS_TOKEN_URL, HttpMethod.POST, request, KakaoTokenResponse.class
+                ACCESS_TOKEN_URL, HttpMethod.POST, request, KakaoTokenResponse.class
         );
 
         return response.getBody();

--- a/src/main/java/com/hyun/udong/auth/infrastructure/client/KakaoOAuthClient.java
+++ b/src/main/java/com/hyun/udong/auth/infrastructure/client/KakaoOAuthClient.java
@@ -61,4 +61,24 @@ public class KakaoOAuthClient {
 
         return response.getBody();
     }
+
+    public KakaoTokenResponse refreshTokens(String refreshToken) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "refresh_token");
+        params.add("client_id", clientId);
+        params.add("refresh_token", refreshToken);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
+                ACCESS_TOKEN_URL, HttpMethod.POST, request, KakaoTokenResponse.class
+        );
+
+        return response.getBody();
+    }
 }

--- a/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
@@ -27,4 +27,10 @@ public class AuthController {
         AccessTokenResponse accessToken = authService.kakaoLogin(code);
         return ResponseEntity.ok().body(accessToken);
     }
+
+    @GetMapping("/oauth/kakao/refresh")
+    public ResponseEntity<AccessTokenResponse> refreshIdToken(@RequestParam("refreshToken") final String refreshToken) {
+        AccessTokenResponse accessToken = authService.refreshTokens(refreshToken);
+        return ResponseEntity.ok().body(accessToken);
+    }
 }

--- a/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
@@ -16,8 +16,13 @@ public class AuthController {
 
     private final AuthService authService;
 
+    @GetMapping("/oauth/kakao/link")
+    public ResponseEntity<String> getOAuthUrl() {
+        String oAuthUrl = authService.getOAuthUrl();
+        return ResponseEntity.ok().body(oAuthUrl);
+    }
 
-    @GetMapping("/login/kakao")
+    @GetMapping("/oauth/kakao")
     public ResponseEntity<AccessTokenResponse> kakaoLogin(@RequestParam("code") final String code) {
         AccessTokenResponse accessToken = authService.kakaoLogin(code);
         return ResponseEntity.ok().body(accessToken);

--- a/src/main/java/com/hyun/udong/auth/presentation/dto/AccessTokenResponse.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/dto/AccessTokenResponse.java
@@ -1,4 +1,4 @@
 package com.hyun.udong.auth.presentation.dto;
 
-public record AccessTokenResponse(String accessToken, long expiredTime) {
+public record AccessTokenResponse(String accessToken, long expiredTime, String refreshToken) {
 }

--- a/src/main/java/com/hyun/udong/common/config/CorsConfig.java
+++ b/src/main/java/com/hyun/udong/common/config/CorsConfig.java
@@ -1,4 +1,4 @@
-package com.hyun.udong.config;
+package com.hyun.udong.common.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/hyun/udong/common/exception/ErrorCode.java
+++ b/src/main/java/com/hyun/udong/common/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package com.hyun.udong.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Getter
+public enum ErrorCode {
+    MEMBER_NOT_FOUND(BAD_REQUEST, "해당하는 회원이 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/hyun/udong/common/exception/ErrorResponse.java
+++ b/src/main/java/com/hyun/udong/common/exception/ErrorResponse.java
@@ -1,0 +1,13 @@
+package com.hyun.udong.common.exception;
+
+public class ErrorResponse {
+    private final String message;
+
+    public ErrorResponse(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/hyun/udong/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hyun/udong/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.hyun.udong.common.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(UdongException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(UdongException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        ErrorResponse errorResponse = new ErrorResponse(errorCode.getMessage());
+        return ResponseEntity.status(ex.getStatus()).body(errorResponse);
+    }
+}

--- a/src/main/java/com/hyun/udong/common/exception/UdongException.java
+++ b/src/main/java/com/hyun/udong/common/exception/UdongException.java
@@ -1,0 +1,20 @@
+package com.hyun.udong.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UdongException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public UdongException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public HttpStatus getStatus() {
+        return errorCode.getStatus();
+    }
+}

--- a/src/main/java/com/hyun/udong/config/CorsConfig.java
+++ b/src/main/java/com/hyun/udong/config/CorsConfig.java
@@ -1,0 +1,26 @@
+package com.hyun.udong.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.ArrayList;
+
+@Configuration
+@RequiredArgsConstructor
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        ArrayList<String> allowedOriginPatterns = new ArrayList<>();
+        allowedOriginPatterns.add("http://localhost:5173");
+
+        String[] patterns = allowedOriginPatterns.toArray(String[]::new);
+        registry.addMapping("/**")
+                .allowedMethods("*")
+                .allowedOriginPatterns(patterns)
+                .exposedHeaders("Set-Cookie")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/java/com/hyun/udong/member/application/service/MemberService.java
+++ b/src/main/java/com/hyun/udong/member/application/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.hyun.udong.member.application.service;
 
 import com.hyun.udong.member.domain.Member;
+import com.hyun.udong.member.exception.MemberNotFoundException;
 import com.hyun.udong.member.infrastructure.repository.MemberRepository;
 import com.hyun.udong.member.presentation.dto.MemberResponse;
 import lombok.RequiredArgsConstructor;
@@ -28,13 +29,14 @@ public class MemberService {
     }
 
     public MemberResponse getMemberById(Long id) {
-        Member member = memberRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당하는 회원이 없습니다."));
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> MemberNotFoundException.EXCEPTION);
 
         return MemberResponse.from(member);
     }
 
     public Member findByRefreshToken(String refreshToken) {
         return memberRepository.findByRefreshToken(refreshToken)
-                .orElseThrow(() -> new IllegalArgumentException("해당하는 회원이 없습니다."));
+                .orElseThrow(() -> MemberNotFoundException.EXCEPTION);
     }
 }

--- a/src/main/java/com/hyun/udong/member/application/service/MemberService.java
+++ b/src/main/java/com/hyun/udong/member/application/service/MemberService.java
@@ -32,4 +32,9 @@ public class MemberService {
 
         return MemberResponse.from(member);
     }
+
+    public Member findByRefreshToken(String refreshToken) {
+        return memberRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 회원이 없습니다."));
+    }
 }

--- a/src/main/java/com/hyun/udong/member/application/service/MemberService.java
+++ b/src/main/java/com/hyun/udong/member/application/service/MemberService.java
@@ -21,8 +21,6 @@ public class MemberService {
         Optional<Member> foundMember = memberRepository.findBySocialIdAndSocialType(member.getSocialId(), member.getSocialType());
 
         if (foundMember.isPresent()) {
-            foundMember.get().updateProfile(member.getNickname(), member.getProfileImageUrl());
-
             return MemberResponse.from(foundMember.get());
         }
 

--- a/src/main/java/com/hyun/udong/member/domain/Member.java
+++ b/src/main/java/com/hyun/udong/member/domain/Member.java
@@ -28,6 +28,8 @@ public class Member {
 
     private String profileImageUrl;
 
+    private String refreshToken;
+
     public Member(Long socialId, SocialType socialType, String nickname, String profileImageUrl) {
         this.socialId = socialId;
         this.socialType = socialType;
@@ -38,5 +40,9 @@ public class Member {
     public void updateProfile(String nickname, String profileImageUrl) {
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/com/hyun/udong/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/hyun/udong/member/exception/MemberNotFoundException.java
@@ -1,0 +1,12 @@
+package com.hyun.udong.member.exception;
+
+import com.hyun.udong.common.exception.ErrorCode;
+import com.hyun.udong.common.exception.UdongException;
+
+public class MemberNotFoundException extends UdongException {
+    public static final UdongException EXCEPTION = new MemberNotFoundException();
+
+    private MemberNotFoundException() {
+        super(ErrorCode.MEMBER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/hyun/udong/member/infrastructure/repository/MemberRepository.java
+++ b/src/main/java/com/hyun/udong/member/infrastructure/repository/MemberRepository.java
@@ -9,5 +9,7 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findBySocialIdAndSocialType(Long socialId, SocialType socialType);
+
+    Optional<Member> findByRefreshToken(String refreshToken);
 }
 

--- a/src/test/java/com/hyun/udong/member/application/service/MemberServiceTest.java
+++ b/src/test/java/com/hyun/udong/member/application/service/MemberServiceTest.java
@@ -42,17 +42,17 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("기존 사용자일 경우 사용자 정보를 수정한다.")
+    @DisplayName("기존 사용자일 경우 사용자 정보를 반환한다.")
     void updateMember() {
-        Member member = new Member(2L, SocialType.KAKAO, "짱아아", "https://user2.com");
+        Member member = new Member(2L, SocialType.KAKAO, "짱아", "https://user2.com");
 
         MemberResponse updatedMember = memberService.save(member);
 
         MemberResponse findMember = memberService.getMemberById(updatedMember.getId());
         assertAll(
                 () -> assertThat(findMember.getId()).isEqualTo(updatedMember.getId()),
-                () -> assertThat(findMember.getNickname()).isEqualTo("짱아아"),
-                () -> assertThat(findMember.getProfileImageUrl()).isEqualTo("https://user2.com")
+                () -> assertThat(findMember.getNickname()).isEqualTo(updatedMember.getNickname()),
+                () -> assertThat(findMember.getProfileImageUrl()).isEqualTo(updatedMember.getProfileImageUrl())
         );
     }
 }

--- a/src/test/java/com/hyun/udong/member/application/service/MemberServiceTest.java
+++ b/src/test/java/com/hyun/udong/member/application/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package com.hyun.udong.member.application.service;
 
 import com.hyun.udong.member.domain.Member;
 import com.hyun.udong.member.domain.SocialType;
+import com.hyun.udong.member.exception.MemberNotFoundException;
 import com.hyun.udong.member.presentation.dto.MemberResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
@@ -54,5 +56,17 @@ class MemberServiceTest {
                 () -> assertThat(findMember.getNickname()).isEqualTo(updatedMember.getNickname()),
                 () -> assertThat(findMember.getProfileImageUrl()).isEqualTo(updatedMember.getProfileImageUrl())
         );
+    }
+
+    @Test
+    @DisplayName("id로 사용자 정보를 조회했을 때 없는 사용자일 경우 예외를 발생시킨다.")
+    void getMemberByIdWithNotExists() {
+        assertThrows(MemberNotFoundException.class, () -> memberService.getMemberById(100L));
+    }
+
+    @Test
+    @DisplayName("없는 refresh token으로 사용자 정보를 조회했을 때 예외를 발생시킨다.")
+    void findByRefreshTokenWithNotExists() {
+        assertThrows(MemberNotFoundException.class, () -> memberService.findByRefreshToken(""));
     }
 }


### PR DESCRIPTION
## #️⃣ Issue
- close #5


## 🧑🏻‍🏫 메인 리뷰어 지정
- 메인 리뷰어 : @blue000927 


## 📝 요약
<!--- 변경 사항에 대한 간략한 요약을 작성해주세요. -->
카카오 로그인 링크 api 추가, refresh_token 저장하고 id_token&access_token 갱신하는 로직 추가

## 🛠 작업 내용
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1. Cursor AI를 통해 프론트단을 따로 구현해 카카오 oauth 링크 api를 제공하는 메서드를 추가했습니다.
2. `id_token`과 `access_token`의 짧은 만료 기한을 위해 `refresh_token`을 활용하고자 했습니다.
3. 사용자가 토큰 갱신 요청 시 `refresh_token`이 1달 미만이라면 카카오에서 자동으로 `refresh_token`을 갱신하여 보내주기 때문에 응답에 `refresh_token`이 있다면 DB의 값도 갱신합니다.


## References
<!--- 사용된 레퍼런스에 대한 링크를 남겨주세요. -->


## 🤔 리뷰 시 참고 사항
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 이번주에 외부 api 테스트 전략 듣고 테스트 코드 추가해보도록 하겠습니다!
- 슬랙으로 말씀드렸던 OIDC 로그인에 대해 고민해봐야할 것 같습니다.
- 지금은 프로젝트의 규모가 작기 때문에 추가적인 학습이 필요없는 DB에 `refresh_token`을 저장했지만 DB는 디스크 기반이라 I/O작업 시 속도가 느리고 만료된 토큰을 계속 저장하고 있어야 합니다. redis를 사용하면 TTL 설정이 가능하며 메모리 기반이므로 추후에 전환해볼 의향이 있습니다. 
- `ConcurrentHashMap`을 사용할까 했지만 TTL 기능이 없다는 점, JVM 메모리에 저장되므로 애플리케이션이 종료되면 데이터가 날아간다는 점 때문에 추후에 redis를 도입하는 게 낫다고 판단했는데 어떻게 생각하시나요?!

## ✅ 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] PR을 연관되는 github issue에 연결했습니다.
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트 코드가 필요없는 이유가 있습니다.
