### PR TITLE
[#8] 카카오 로그인 OIDC -> 자체 JWT 발급 방식 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     runtimeOnly 'com.h2database:h2'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
+++ b/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
@@ -16,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Date;
 
 @Service
 @Transactional(readOnly = true)
@@ -36,8 +35,8 @@ public class AuthService {
         Member member = memberService.findBySocialIdAndSocialType(profile.getId(), SocialType.KAKAO)
                 .orElseGet(() -> memberService.save(profile.toMember()));
 
-        String accessToken = jwtTokenProvider.generateAccessToken(member.getId(), new Date());
-        String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId(), new Date());
+        String accessToken = jwtTokenProvider.generateAccessToken(member.getId());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId());
         updateRefreshToken(member.getId(), refreshToken);
 
         AuthTokens authTokens = new AuthTokens(accessToken, jwtTokenProvider.getTokenExpireTime(accessToken), refreshToken, jwtTokenProvider.getTokenExpireTime(refreshToken));
@@ -50,14 +49,13 @@ public class AuthService {
 
         validateIsTokenOwner(refreshToken, memberId);
 
-        String newAccessToken = jwtTokenProvider.generateAccessToken(memberId, new Date());
-        String newRefreshToken = jwtTokenProvider.generateRefreshToken(memberId, new Date());
+        String newAccessToken = jwtTokenProvider.generateAccessToken(memberId);
+        String newRefreshToken = jwtTokenProvider.generateRefreshToken(memberId);
 
         Member member = updateRefreshToken(memberId, newRefreshToken);
 
         AuthTokens authTokens = new AuthTokens(newAccessToken, jwtTokenProvider.getTokenExpireTime(newAccessToken), newRefreshToken, jwtTokenProvider.getTokenExpireTime(newRefreshToken));
         return new LoginResponse(member.getId(), member.getNickname(), authTokens);
-
     }
 
     private long extractMemberId(String refreshToken) {

--- a/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
+++ b/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
@@ -8,6 +8,7 @@ import com.hyun.udong.auth.presentation.dto.LoginResponse;
 import com.hyun.udong.auth.util.JwtTokenProvider;
 import com.hyun.udong.member.application.service.MemberService;
 import com.hyun.udong.member.domain.Member;
+import com.hyun.udong.member.domain.SocialType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +27,8 @@ public class AuthService {
         KakaoTokenResponse kakaoTokenResponse = kakaoOAuthClient.getToken(code);
         KakaoProfileResponse profile = kakaoOAuthClient.getUserProfile(kakaoTokenResponse.getAccessToken());
 
-        Member member = memberService.save(profile.toMember());
+        Member member = memberService.findBySocialIdAndSocialType(profile.getId(), SocialType.KAKAO)
+                .orElseGet(() -> memberService.save(profile.toMember()));
 
         String accessToken = jwtTokenProvider.generateAccessToken(member.getId());
         String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId());

--- a/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
+++ b/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
@@ -38,7 +38,7 @@ public class AuthService {
 
     @Transactional
     public LoginResponse refreshTokens(String refreshToken) {
-        Long memberId = Long.parseLong(jwtTokenProvider.getMemberIdFromToken(refreshToken));
+        Long memberId = Long.parseLong(jwtTokenProvider.getSubjectFromToken(refreshToken));
         String newAccessToken = jwtTokenProvider.generateAccessToken(memberId);
         String newRefreshToken = jwtTokenProvider.generateRefreshToken(memberId);
 

--- a/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
+++ b/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
@@ -84,6 +84,6 @@ public class AuthService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> MemberNotFoundException.EXCEPTION);
         member.updateRefreshToken(refreshToken);
-        return memberRepository.save(member);
+        return member;
     }
 }

--- a/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
+++ b/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
@@ -26,7 +26,7 @@ public class AuthService {
         KakaoTokenResponse kakaoTokenResponse = kakaoOAuthClient.getToken(code);
         KakaoProfileResponse profile = kakaoOAuthClient.getUserProfile(kakaoTokenResponse.getAccessToken());
 
-        Member member = memberService.save2(profile.toMember());
+        Member member = memberService.save(profile.toMember());
 
         String accessToken = jwtTokenProvider.generateAccessToken(member.getId());
         String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId());

--- a/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
+++ b/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
@@ -16,10 +16,6 @@ public class AuthService {
     private final KakaoOAuthClient kakaoOAuthClient;
     private final MemberService memberService;
 
-    public String getOAuthUrl() {
-        return kakaoOAuthClient.getOAuthUrl();
-    }
-
     public AccessTokenResponse kakaoLogin(String code) {
         KakaoTokenResponse kakaoTokenResponse = kakaoOAuthClient.getToken(code);
         KakaoProfileResponse profile = kakaoOAuthClient.getUserProfile(kakaoTokenResponse.getAccessToken());

--- a/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
+++ b/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
@@ -32,7 +32,7 @@ public class AuthService {
         String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId());
         memberService.updateRefreshToken(member.getId(), refreshToken);
 
-        AuthTokens authTokens = new AuthTokens(accessToken, jwtTokenProvider.getAccessTokenExpireTime(), refreshToken, jwtTokenProvider.getRefreshTokenExpireTime());
+        AuthTokens authTokens = new AuthTokens(accessToken, jwtTokenProvider.getTokenExpireTime(accessToken), refreshToken, jwtTokenProvider.getTokenExpireTime(refreshToken));
         return new LoginResponse(member.getId(), member.getNickname(), authTokens);
     }
 
@@ -44,7 +44,7 @@ public class AuthService {
 
         Member member = memberService.updateRefreshToken(memberId, newRefreshToken);
 
-        AuthTokens authTokens = new AuthTokens(newAccessToken, jwtTokenProvider.getAccessTokenExpireTime(), newRefreshToken, jwtTokenProvider.getRefreshTokenExpireTime());
+        AuthTokens authTokens = new AuthTokens(newAccessToken, jwtTokenProvider.getTokenExpireTime(newAccessToken), newRefreshToken, jwtTokenProvider.getTokenExpireTime(newRefreshToken));
         return new LoginResponse(member.getId(), member.getNickname(), authTokens);
 
     }

--- a/src/main/java/com/hyun/udong/auth/exception/ExpiredTokenException.java
+++ b/src/main/java/com/hyun/udong/auth/exception/ExpiredTokenException.java
@@ -1,0 +1,12 @@
+package com.hyun.udong.auth.exception;
+
+import com.hyun.udong.common.exception.ErrorCode;
+import com.hyun.udong.common.exception.UdongException;
+
+public class ExpiredTokenException extends UdongException {
+    public static final ExpiredTokenException EXCEPTION = new ExpiredTokenException();
+
+    private ExpiredTokenException() {
+        super(ErrorCode.TOKEN_EXPIRED);
+    }
+}

--- a/src/main/java/com/hyun/udong/auth/exception/InvalidTokenException.java
+++ b/src/main/java/com/hyun/udong/auth/exception/InvalidTokenException.java
@@ -1,0 +1,12 @@
+package com.hyun.udong.auth.exception;
+
+import com.hyun.udong.common.exception.ErrorCode;
+import com.hyun.udong.common.exception.UdongException;
+
+public class InvalidTokenException extends UdongException {
+    public static final InvalidTokenException EXCEPTION = new InvalidTokenException();
+
+    private InvalidTokenException() {
+        super(ErrorCode.INVALID_TOKEN);
+    }
+}

--- a/src/main/java/com/hyun/udong/auth/infrastructure/client/KakaoOAuthClient.java
+++ b/src/main/java/com/hyun/udong/auth/infrastructure/client/KakaoOAuthClient.java
@@ -56,24 +56,4 @@ public class KakaoOAuthClient {
 
         return response.getBody();
     }
-
-    public KakaoTokenResponse refreshTokens(String refreshToken) {
-        RestTemplate restTemplate = new RestTemplate();
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
-
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "refresh_token");
-        params.add("client_id", clientId);
-        params.add("refresh_token", refreshToken);
-
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
-        ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
-                ACCESS_TOKEN_URL, HttpMethod.POST, request, KakaoTokenResponse.class
-        );
-
-        return response.getBody();
-    }
 }

--- a/src/main/java/com/hyun/udong/auth/infrastructure/client/KakaoOAuthClient.java
+++ b/src/main/java/com/hyun/udong/auth/infrastructure/client/KakaoOAuthClient.java
@@ -12,7 +12,6 @@ import org.springframework.web.client.RestTemplate;
 @Component
 public class KakaoOAuthClient {
 
-    private static final String AUTHORIZE_URL = "https://kauth.kakao.com/oauth/authorize?client_id=";
     private static final String ACCESS_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
     private static final String USER_PROFILE_URL = "https://kapi.kakao.com/v2/user/me";
 
@@ -21,10 +20,6 @@ public class KakaoOAuthClient {
 
     @Value("${social.kakao.redirect-uri}")
     private String redirectUri;
-
-    public String getOAuthUrl() {
-        return AUTHORIZE_URL + clientId + "&redirect_uri=" + redirectUri + "&response_type=code";
-    }
 
     public KakaoProfileResponse getUserProfile(String accessToken) {
         RestTemplate restTemplate = new RestTemplate();

--- a/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.hyun.udong.auth.presentation.controller;
 
 import com.hyun.udong.auth.application.service.AuthService;
-import com.hyun.udong.auth.presentation.dto.AccessTokenResponse;
+import com.hyun.udong.auth.presentation.dto.LoginResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,16 +16,15 @@ public class AuthController {
 
     private final AuthService authService;
 
-
     @GetMapping("/oauth/kakao")
-    public ResponseEntity<AccessTokenResponse> kakaoLogin(@RequestParam("code") final String code) {
-        AccessTokenResponse accessToken = authService.kakaoLogin(code);
-        return ResponseEntity.ok().body(accessToken);
+    public ResponseEntity<LoginResponse> kakaoLogin(@RequestParam("code") final String code) {
+        LoginResponse loginResponse = authService.kakaoLogin(code);
+        return ResponseEntity.ok().body(loginResponse);
     }
 
-    @GetMapping("/oauth/kakao/refresh")
-    public ResponseEntity<AccessTokenResponse> refreshIdToken(@RequestParam("refreshToken") final String refreshToken) {
-        AccessTokenResponse accessToken = authService.refreshTokens(refreshToken);
-        return ResponseEntity.ok().body(accessToken);
+    @GetMapping("/token/refresh")
+    public ResponseEntity<LoginResponse> refreshIdToken(@RequestParam("refreshToken") final String refreshToken) {
+        LoginResponse loginResponse = authService.refreshTokens(refreshToken);
+        return ResponseEntity.ok().body(loginResponse);
     }
 }

--- a/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
@@ -23,7 +23,7 @@ public class AuthController {
     }
 
     @GetMapping("/token/refresh")
-    public ResponseEntity<LoginResponse> refreshIdToken(@RequestParam("refreshToken") final String refreshToken) {
+    public ResponseEntity<LoginResponse> refreshTokens(@RequestParam("refreshToken") final String refreshToken) {
         LoginResponse loginResponse = authService.refreshTokens(refreshToken);
         return ResponseEntity.ok().body(loginResponse);
     }

--- a/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
@@ -16,11 +16,6 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @GetMapping("/oauth/kakao/link")
-    public ResponseEntity<String> getOAuthUrl() {
-        String oAuthUrl = authService.getOAuthUrl();
-        return ResponseEntity.ok().body(oAuthUrl);
-    }
 
     @GetMapping("/oauth/kakao")
     public ResponseEntity<AccessTokenResponse> kakaoLogin(@RequestParam("code") final String code) {

--- a/src/main/java/com/hyun/udong/auth/presentation/dto/AccessTokenResponse.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/dto/AccessTokenResponse.java
@@ -1,4 +1,0 @@
-package com.hyun.udong.auth.presentation.dto;
-
-public record AccessTokenResponse(String accessToken, long expiredTime, String refreshToken) {
-}

--- a/src/main/java/com/hyun/udong/auth/presentation/dto/AuthTokens.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/dto/AuthTokens.java
@@ -1,0 +1,4 @@
+package com.hyun.udong.auth.presentation.dto;
+
+public record AuthTokens(String accessToken, long accessTokenAge, String refreshToken, long refreshTokenAge) {
+}

--- a/src/main/java/com/hyun/udong/auth/presentation/dto/AuthTokens.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/dto/AuthTokens.java
@@ -1,4 +1,7 @@
 package com.hyun.udong.auth.presentation.dto;
 
-public record AuthTokens(String accessToken, long accessTokenAge, String refreshToken, long refreshTokenAge) {
+import java.time.LocalDateTime;
+
+public record AuthTokens(String accessToken, LocalDateTime accessTokenExpDate, String refreshToken,
+                         LocalDateTime refreshTokenExpDate) {
 }

--- a/src/main/java/com/hyun/udong/auth/presentation/dto/KakaoProfileResponse.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/dto/KakaoProfileResponse.java
@@ -20,6 +20,14 @@ public class KakaoProfileResponse {
 
     private KakaoAccount kakaoAccount;
 
+    public KakaoProfileResponse(Long id, String nickname, String profileImage) {
+        this.id = id;
+        this.kakaoAccount = new KakaoAccount();
+        this.kakaoAccount.profile = new KakaoAccount.Profile();
+        this.kakaoAccount.profile.nickname = nickname;
+        this.kakaoAccount.profile.profileImageUrl = profileImage;
+    }
+
     @Getter
     public static class KakaoAccount {
 

--- a/src/main/java/com/hyun/udong/auth/presentation/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/dto/KakaoTokenResponse.java
@@ -26,4 +26,8 @@ public class KakaoTokenResponse {
     private Integer refreshTokenExpiresIn;
 
     private String scope;
+
+    public KakaoTokenResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
 }

--- a/src/main/java/com/hyun/udong/auth/presentation/dto/LoginResponse.java
+++ b/src/main/java/com/hyun/udong/auth/presentation/dto/LoginResponse.java
@@ -1,0 +1,18 @@
+package com.hyun.udong.auth.presentation.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginResponse {
+    private Long id;
+    private String nickname;
+    private AuthTokens token;
+
+    public LoginResponse(Long id, String nickname, AuthTokens token) {
+        this.id = id;
+        this.nickname = nickname;
+        this.token = token;
+    }
+}

--- a/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
@@ -1,0 +1,67 @@
+package com.hyun.udong.auth.util;
+
+import com.hyun.udong.auth.exception.InvalidTokenException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+import static io.jsonwebtoken.Jwts.builder;
+import static io.jsonwebtoken.Jwts.parserBuilder;
+
+@Component
+public class JwtTokenProvider {
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1_000L * 60 * 60;
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1_000L * 60 * 60 * 24 * 14;
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    private Key getSecretKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(Long id) {
+        return builder()
+                .setSubject(id.toString())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME))
+                .signWith(getSecretKey())
+                .compact();
+    }
+
+    public String generateRefreshToken(Long id) {
+        return builder()
+                .setSubject(id.toString())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(getSecretKey())
+                .compact();
+    }
+
+    public long getAccessTokenExpireTime() {
+        return ACCESS_TOKEN_EXPIRE_TIME;
+    }
+
+    public long getRefreshTokenExpireTime() {
+        return REFRESH_TOKEN_EXPIRE_TIME;
+    }
+
+    public Jws<Claims> parseToken(String token) {
+        try {
+            return parserBuilder().setSigningKey(getSecretKey()).build().parseClaimsJws(token);
+        } catch (Exception e) {
+            throw InvalidTokenException.EXCEPTION;
+        }
+    }
+
+    public String getMemberIdFromToken(String token) {
+        return parseToken(token).getBody().getSubject();
+    }
+}
+

--- a/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
@@ -1,7 +1,9 @@
 package com.hyun.udong.auth.util;
 
+import com.hyun.udong.auth.exception.ExpiredTokenException;
 import com.hyun.udong.auth.exception.InvalidTokenException;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -52,9 +54,11 @@ public class JwtTokenProvider {
         return REFRESH_TOKEN_EXPIRE_TIME;
     }
 
-    public Jws<Claims> parseToken(String token) {
+    private Jws<Claims> parseToken(String token) {
         try {
             return parserBuilder().setSigningKey(getSecretKey()).build().parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            throw ExpiredTokenException.EXCEPTION;
         } catch (Exception e) {
             throw InvalidTokenException.EXCEPTION;
         }

--- a/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 
 import static io.jsonwebtoken.Jwts.builder;
@@ -46,12 +48,9 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public long getAccessTokenExpireTime() {
-        return ACCESS_TOKEN_EXPIRE_TIME;
-    }
-
-    public long getRefreshTokenExpireTime() {
-        return REFRESH_TOKEN_EXPIRE_TIME;
+    public LocalDateTime getTokenExpireTime(String token) {
+        Date expiration = parseToken(token).getBody().getExpiration();
+        return LocalDateTime.ofInstant(expiration.toInstant(), ZoneId.systemDefault());
     }
 
     private Jws<Claims> parseToken(String token) {

--- a/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
@@ -67,7 +67,7 @@ public class JwtTokenProvider {
         }
     }
 
-    public String getMemberIdFromToken(String token) {
+    public String getSubjectFromToken(String token) {
         return parseToken(token).getBody().getSubject();
     }
 }

--- a/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
@@ -36,20 +36,21 @@ public class JwtTokenProvider {
         return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String generateAccessToken(Long id) {
+
+    public String generateAccessToken(Long id, Date issuedAt) {
         return builder()
                 .setSubject(id.toString())
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpireTime))
+                .setIssuedAt(issuedAt)
+                .setExpiration(new Date(issuedAt.getTime() + accessTokenExpireTime))
                 .signWith(getSecretKey())
                 .compact();
     }
 
-    public String generateRefreshToken(Long id) {
+    public String generateRefreshToken(Long id, Date issuedAt) {
         return builder()
                 .setSubject(id.toString())
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpireTime))
+                .setIssuedAt(issuedAt)
+                .setExpiration(new Date(issuedAt.getTime() + refreshTokenExpireTime))
                 .signWith(getSecretKey())
                 .compact();
     }

--- a/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
@@ -36,21 +36,19 @@ public class JwtTokenProvider {
         return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
-
-    public String generateAccessToken(Long id, Date issuedAt) {
-        return builder()
-                .setSubject(id.toString())
-                .setIssuedAt(issuedAt)
-                .setExpiration(new Date(issuedAt.getTime() + accessTokenExpireTime))
-                .signWith(getSecretKey())
-                .compact();
+    public String generateAccessToken(Long id) {
+        return createToken(id, accessTokenExpireTime);
     }
 
-    public String generateRefreshToken(Long id, Date issuedAt) {
+    public String generateRefreshToken(Long id) {
+        return createToken(id, refreshTokenExpireTime);
+    }
+
+    private String createToken(Long id, long expireTime) {
         return builder()
                 .setSubject(id.toString())
-                .setIssuedAt(issuedAt)
-                .setExpiration(new Date(issuedAt.getTime() + refreshTokenExpireTime))
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expireTime))
                 .signWith(getSecretKey())
                 .compact();
     }

--- a/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
@@ -20,8 +20,12 @@ import static io.jsonwebtoken.Jwts.parserBuilder;
 
 @Component
 public class JwtTokenProvider {
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1_000L * 60 * 60;
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1_000L * 60 * 60 * 24 * 14;
+
+    @Value("${ACCESS_TOKEN_EXPIRE_TIME}")
+    private long accessTokenExpireTime;
+
+    @Value("${REFRESH_TOKEN_EXPIRE_TIME}")
+    private long refreshTokenExpireTime;
 
     @Value("${jwt.secret}")
     private String secret;
@@ -34,7 +38,7 @@ public class JwtTokenProvider {
         return builder()
                 .setSubject(id.toString())
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME))
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpireTime))
                 .signWith(getSecretKey())
                 .compact();
     }
@@ -43,7 +47,7 @@ public class JwtTokenProvider {
         return builder()
                 .setSubject(id.toString())
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRE_TIME))
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpireTime))
                 .signWith(getSecretKey())
                 .compact();
     }

--- a/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/hyun/udong/auth/util/JwtTokenProvider.java
@@ -6,6 +6,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -19,6 +20,7 @@ import static io.jsonwebtoken.Jwts.builder;
 import static io.jsonwebtoken.Jwts.parserBuilder;
 
 @Component
+@Slf4j
 public class JwtTokenProvider {
 
     @Value("${ACCESS_TOKEN_EXPIRE_TIME}")
@@ -63,6 +65,7 @@ public class JwtTokenProvider {
         } catch (ExpiredJwtException e) {
             throw ExpiredTokenException.EXCEPTION;
         } catch (Exception e) {
+            log.error("검증 실패 토큰: {}", token, e);
             throw InvalidTokenException.EXCEPTION;
         }
     }

--- a/src/main/java/com/hyun/udong/common/exception/ErrorCode.java
+++ b/src/main/java/com/hyun/udong/common/exception/ErrorCode.java
@@ -9,7 +9,8 @@ import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 @Getter
 public enum ErrorCode {
     MEMBER_NOT_FOUND(BAD_REQUEST, "해당하는 회원이 없습니다."),
-    INVALID_TOKEN(UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+    INVALID_TOKEN(UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    TOKEN_EXPIRED(UNAUTHORIZED, "만료된 토큰입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/hyun/udong/common/exception/ErrorCode.java
+++ b/src/main/java/com/hyun/udong/common/exception/ErrorCode.java
@@ -4,10 +4,12 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 @Getter
 public enum ErrorCode {
-    MEMBER_NOT_FOUND(BAD_REQUEST, "해당하는 회원이 없습니다.");
+    MEMBER_NOT_FOUND(BAD_REQUEST, "해당하는 회원이 없습니다."),
+    INVALID_TOKEN(UNAUTHORIZED, "유효하지 않은 토큰입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/hyun/udong/member/application/service/MemberService.java
+++ b/src/main/java/com/hyun/udong/member/application/service/MemberService.java
@@ -8,8 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -18,18 +16,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public MemberResponse save(Member member) {
-        Optional<Member> foundMember = memberRepository.findBySocialIdAndSocialType(member.getSocialId(), member.getSocialType());
-
-        if (foundMember.isPresent()) {
-            return MemberResponse.from(foundMember.get());
-        }
-
-        return MemberResponse.from(memberRepository.save(member));
-    }
-
-    @Transactional
-    public Member save2(Member member) {
+    public Member save(Member member) {
         return memberRepository.findBySocialIdAndSocialType(member.getSocialId(), member.getSocialType())
                 .orElseGet(() -> memberRepository.save(member));
     }
@@ -43,11 +30,6 @@ public class MemberService {
 
     public Member findById(Long id) {
         return memberRepository.findById(id)
-                .orElseThrow(() -> MemberNotFoundException.EXCEPTION);
-    }
-
-    public Member findByRefreshToken(String refreshToken) {
-        return memberRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(() -> MemberNotFoundException.EXCEPTION);
     }
 

--- a/src/main/java/com/hyun/udong/member/application/service/MemberService.java
+++ b/src/main/java/com/hyun/udong/member/application/service/MemberService.java
@@ -1,11 +1,14 @@
 package com.hyun.udong.member.application.service;
 
 import com.hyun.udong.member.domain.Member;
+import com.hyun.udong.member.domain.SocialType;
 import com.hyun.udong.member.exception.MemberNotFoundException;
 import com.hyun.udong.member.infrastructure.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -16,8 +19,11 @@ public class MemberService {
 
     @Transactional
     public Member save(Member member) {
-        return memberRepository.findBySocialIdAndSocialType(member.getSocialId(), member.getSocialType())
-                .orElseGet(() -> memberRepository.save(member));
+        return memberRepository.save(member);
+    }
+
+    public Optional<Member> findBySocialIdAndSocialType(Long socialId, SocialType socialType) {
+        return memberRepository.findBySocialIdAndSocialType(socialId, socialType);
     }
 
     public Member findById(Long id) {

--- a/src/main/java/com/hyun/udong/member/application/service/MemberService.java
+++ b/src/main/java/com/hyun/udong/member/application/service/MemberService.java
@@ -31,9 +31,4 @@ public class MemberService {
                 .orElseThrow(() -> MemberNotFoundException.EXCEPTION);
     }
 
-    public Member updateRefreshToken(Long id, String refreshToken) {
-        Member member = findById(id);
-        member.updateRefreshToken(refreshToken);
-        return member;
-    }
 }

--- a/src/main/java/com/hyun/udong/member/application/service/MemberService.java
+++ b/src/main/java/com/hyun/udong/member/application/service/MemberService.java
@@ -28,6 +28,12 @@ public class MemberService {
         return MemberResponse.from(memberRepository.save(member));
     }
 
+    @Transactional
+    public Member save2(Member member) {
+        return memberRepository.findBySocialIdAndSocialType(member.getSocialId(), member.getSocialType())
+                .orElseGet(() -> memberRepository.save(member));
+    }
+
     public MemberResponse getMemberById(Long id) {
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> MemberNotFoundException.EXCEPTION);
@@ -35,8 +41,19 @@ public class MemberService {
         return MemberResponse.from(member);
     }
 
+    public Member findById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> MemberNotFoundException.EXCEPTION);
+    }
+
     public Member findByRefreshToken(String refreshToken) {
         return memberRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(() -> MemberNotFoundException.EXCEPTION);
+    }
+
+    public Member updateRefreshToken(Long id, String refreshToken) {
+        Member member = findById(id);
+        member.updateRefreshToken(refreshToken);
+        return member;
     }
 }

--- a/src/main/java/com/hyun/udong/member/application/service/MemberService.java
+++ b/src/main/java/com/hyun/udong/member/application/service/MemberService.java
@@ -3,7 +3,6 @@ package com.hyun.udong.member.application.service;
 import com.hyun.udong.member.domain.Member;
 import com.hyun.udong.member.exception.MemberNotFoundException;
 import com.hyun.udong.member.infrastructure.repository.MemberRepository;
-import com.hyun.udong.member.presentation.dto.MemberResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,13 +18,6 @@ public class MemberService {
     public Member save(Member member) {
         return memberRepository.findBySocialIdAndSocialType(member.getSocialId(), member.getSocialType())
                 .orElseGet(() -> memberRepository.save(member));
-    }
-
-    public MemberResponse getMemberById(Long id) {
-        Member member = memberRepository.findById(id)
-                .orElseThrow(() -> MemberNotFoundException.EXCEPTION);
-
-        return MemberResponse.from(member);
     }
 
     public Member findById(Long id) {

--- a/src/main/java/com/hyun/udong/member/domain/Member.java
+++ b/src/main/java/com/hyun/udong/member/domain/Member.java
@@ -37,6 +37,14 @@ public class Member {
         this.profileImageUrl = profileImageUrl;
     }
 
+    public Member(Long id, Long socialId, SocialType socialType, String nickname, String profileImageUrl) {
+        this.id = id;
+        this.socialId = socialId;
+        this.socialType = socialType;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+
     public void updateProfile(String nickname, String profileImageUrl) {
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;

--- a/src/main/java/com/hyun/udong/member/domain/Member.java
+++ b/src/main/java/com/hyun/udong/member/domain/Member.java
@@ -45,11 +45,6 @@ public class Member {
         this.profileImageUrl = profileImageUrl;
     }
 
-    public void updateProfile(String nickname, String profileImageUrl) {
-        this.nickname = nickname;
-        this.profileImageUrl = profileImageUrl;
-    }
-
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,5 @@ social:
 
 jwt:
   secret: ${JWT_SECRET}
+  access-token-expire-time: ${ACCESS_TOKEN_EXPIRE_TIME}  # 1시간 (밀리초)
+  refresh-token-expire-time: ${REFRESH_TOKEN_EXPIRE_TIME}  # 14일 (밀리초)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,3 +25,6 @@ social:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
     redirect-uri: ${GOOGLE_REDIRECT_URI}
+
+jwt:
+  secret: ${JWT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,5 +28,5 @@ social:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-expire-time: ${ACCESS_TOKEN_EXPIRE_TIME}  # 1시간 (밀리초)
-  refresh-token-expire-time: ${REFRESH_TOKEN_EXPIRE_TIME}  # 14일 (밀리초)
+  access-token-expire-time: ${ACCESS_TOKEN_EXPIRE_TIME}
+  refresh-token-expire-time: ${REFRESH_TOKEN_EXPIRE_TIME}

--- a/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
+++ b/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
@@ -9,7 +9,6 @@ import com.hyun.udong.auth.util.JwtTokenProvider;
 import com.hyun.udong.member.application.service.MemberService;
 import com.hyun.udong.member.domain.Member;
 import com.hyun.udong.member.domain.SocialType;
-import com.hyun.udong.member.infrastructure.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,9 +35,6 @@ class AuthServiceTest {
 
     @Autowired
     private AuthService authService;
-
-    @Autowired
-    private MemberRepository memberRepository;
 
     @Test
     @DisplayName("카카오 로그인 시 사용자 정보와 refresh_token이 저장된다.")
@@ -77,7 +73,7 @@ class AuthServiceTest {
         authService.refreshTokens(initialRefreshToken);
 
         // then
-        Member updatedMember = memberRepository.findById(member.getId()).orElseThrow();
+        Member updatedMember = memberService.findById(member.getId());
         then(updatedMember.getRefreshToken()).isNotEqualTo(initialRefreshToken);
     }
 

--- a/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
+++ b/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
@@ -64,7 +64,7 @@ class AuthServiceTest {
         Long memberId = 1L;
         Member member = new Member(100L, SocialType.KAKAO, "hyun", "profile_image");
         member.updateRefreshToken(refreshToken);
-        memberService.save2(member);
+        memberService.save(member);
 
         given(jwtTokenProvider.getMemberIdFromToken(refreshToken)).willReturn(memberId.toString());
         given(jwtTokenProvider.generateAccessToken(memberId)).willReturn("newAccessToken");

--- a/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
+++ b/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
@@ -1,0 +1,80 @@
+package com.hyun.udong.auth.application.service;
+
+import com.hyun.udong.auth.infrastructure.client.KakaoOAuthClient;
+import com.hyun.udong.auth.presentation.dto.KakaoProfileResponse;
+import com.hyun.udong.auth.presentation.dto.KakaoTokenResponse;
+import com.hyun.udong.auth.presentation.dto.LoginResponse;
+import com.hyun.udong.auth.util.JwtTokenProvider;
+import com.hyun.udong.member.application.service.MemberService;
+import com.hyun.udong.member.domain.Member;
+import com.hyun.udong.member.domain.SocialType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+class AuthServiceTest {
+
+    @MockitoBean
+    private KakaoOAuthClient kakaoOAuthClient;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private AuthService authService;
+
+    @Test
+    @DisplayName("카카오 로그인 시 사용자 정보와 refresh_token이 저장된다.")
+    void kakaoLogin_save() {
+        // given
+        String code = "authCode";
+        KakaoTokenResponse kakaoTokenResponse = new KakaoTokenResponse("accessToken");
+        KakaoProfileResponse profile = new KakaoProfileResponse(100L, "hyun", "profile_image");
+        Member member = new Member(1L, 100L, SocialType.KAKAO, "hyun", "profile_image");
+
+        given(kakaoOAuthClient.getToken(code)).willReturn(kakaoTokenResponse);
+        given(kakaoOAuthClient.getUserProfile(kakaoTokenResponse.getAccessToken())).willReturn(profile);
+        given(jwtTokenProvider.generateAccessToken(member.getId())).willReturn("accessToken");
+        given(jwtTokenProvider.generateRefreshToken(member.getId())).willReturn("refreshToken");
+
+        // when
+        LoginResponse response = authService.kakaoLogin(code);
+
+        // then
+        then(response).isNotNull();
+        then(response.getNickname()).isEqualTo(member.getNickname());
+        then(response.getToken().accessToken()).isEqualTo("accessToken");
+        then(response.getToken().refreshToken()).isEqualTo("refreshToken");
+    }
+
+    @Test
+    @DisplayName("refreshToken 재발급 시 새로운 토큰을 저장한다.")
+    void refreshTokens_returnsNewTokens() {
+        // given
+        String refreshToken = "validRefreshToken";
+        Long memberId = 1L;
+        Member member = new Member(100L, SocialType.KAKAO, "hyun", "profile_image");
+        member.updateRefreshToken(refreshToken);
+        memberService.save2(member);
+
+        given(jwtTokenProvider.getMemberIdFromToken(refreshToken)).willReturn(memberId.toString());
+        given(jwtTokenProvider.generateAccessToken(memberId)).willReturn("newAccessToken");
+        given(jwtTokenProvider.generateRefreshToken(memberId)).willReturn("newRefreshToken");
+
+        // when
+        authService.refreshTokens(refreshToken);
+        Member updatedMember = memberService.findById(member.getId());
+
+        // then
+        then(updatedMember.getRefreshToken()).isEqualTo("newRefreshToken");
+    }
+}

--- a/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
+++ b/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
@@ -66,7 +66,7 @@ class AuthServiceTest {
         member.updateRefreshToken(refreshToken);
         memberService.save(member);
 
-        given(jwtTokenProvider.getMemberIdFromToken(refreshToken)).willReturn(memberId.toString());
+        given(jwtTokenProvider.getSubjectFromToken(refreshToken)).willReturn(memberId.toString());
         given(jwtTokenProvider.generateAccessToken(memberId)).willReturn("newAccessToken");
         given(jwtTokenProvider.generateRefreshToken(memberId)).willReturn("newRefreshToken");
 

--- a/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
+++ b/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
@@ -84,7 +84,7 @@ class AuthServiceTest {
 
     @DisplayName("토큰 재발급 시 유효한 코드가 아니면 예외가 발생한다.")
     @Test
-    void testMethodNameHere() {
+    void refreshTokens_throw() {
         String otherRefreshToken = jwtTokenProvider.generateRefreshToken(200L, new Date());
 
         // when & then

--- a/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
+++ b/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
@@ -15,8 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import java.util.Date;
-
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import static org.mockito.BDDMockito.given;
@@ -59,29 +57,29 @@ class AuthServiceTest {
         then(response.getToken().refreshToken()).isEqualTo(member.getRefreshToken());
     }
 
-    @Test
-    @DisplayName("refreshToken 재발급 시 새로운 토큰을 저장한다.")
-    void refreshTokens_ok() {
-        // given
-        Member member = memberService.save(new Member(100L, SocialType.KAKAO, "hyun", "profile_image"));
-        String initialRefreshToken = jwtTokenProvider.generateRefreshToken(member.getId(), new Date(System.currentTimeMillis() - 1000));
-
-        member.updateRefreshToken(initialRefreshToken);
-        memberService.save(member);
-
-        // when
-        authService.refreshTokens(initialRefreshToken);
-
-        // then
-        Member updatedMember = memberService.findById(member.getId());
-        then(updatedMember.getRefreshToken()).isNotEqualTo(initialRefreshToken);
-    }
-
+//    TODO: 시간차를 두면 테스트가 되나 스태틱 모킹 이슈(gradle 관련)로 인해 테스트가 안됨
+//    @Test
+//    @DisplayName("refreshToken 재발급 시 새로운 토큰을 저장한다.")
+//    void refreshTokens_ok() {
+//        // given
+//        Member member = memberService.save(new Member(100L, SocialType.KAKAO, "hyun", "profile_image"));
+//        String initialRefreshToken = jwtTokenProvider.generateRefreshToken(member.getId());
+//
+//        member.updateRefreshToken(initialRefreshToken);
+//        memberService.save(member);
+//
+//        // when
+//        authService.refreshTokens(initialRefreshToken);
+//
+//        // then
+//        Member updatedMember = memberService.findById(member.getId());
+//        then(updatedMember.getRefreshToken()).isNotEqualTo(initialRefreshToken);
+//    }
 
     @DisplayName("토큰 재발급 시 유효한 코드가 아니면 예외가 발생한다.")
     @Test
     void refreshTokens_throw() {
-        String otherRefreshToken = jwtTokenProvider.generateRefreshToken(200L, new Date());
+        String otherRefreshToken = jwtTokenProvider.generateRefreshToken(200L);
 
         // when & then
         thenThrownBy(() -> authService.refreshTokens(otherRefreshToken))

--- a/src/test/java/com/hyun/udong/auth/presentation/controller/AuthControllerTest.java
+++ b/src/test/java/com/hyun/udong/auth/presentation/controller/AuthControllerTest.java
@@ -1,0 +1,55 @@
+package com.hyun.udong.auth.presentation.controller;
+
+import com.hyun.udong.auth.infrastructure.client.KakaoOAuthClient;
+import com.hyun.udong.auth.presentation.dto.KakaoProfileResponse;
+import com.hyun.udong.auth.presentation.dto.KakaoTokenResponse;
+import com.hyun.udong.auth.util.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+class AuthControllerTest {
+
+    public static final long FIRST_SAVED_MEMBER_ID = 1L;
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private KakaoOAuthClient kakaoOAuthClient;
+
+    @DisplayName("카카오 로그인 성공 시 loginResponse가 반환되는지 확인한다.")
+    @Test
+    void kakaoLogin() throws Exception {
+        // given
+        KakaoTokenResponse kakaoTokenResponse = new KakaoTokenResponse("accessToken");
+        KakaoProfileResponse kakaoProfileResponse = new KakaoProfileResponse(100L, "hyun", "profile_image");
+        given(kakaoOAuthClient.getToken(anyString())).willReturn(kakaoTokenResponse);
+        given(kakaoOAuthClient.getUserProfile(anyString())).willReturn(kakaoProfileResponse);
+        given(jwtTokenProvider.generateAccessToken(FIRST_SAVED_MEMBER_ID)).willReturn("accessToken");
+        given(jwtTokenProvider.generateRefreshToken(FIRST_SAVED_MEMBER_ID)).willReturn("refreshToken");
+
+        // when & then
+        mockMvc.perform(get("/auth/oauth/kakao")
+                        .param("code", "authCode"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(FIRST_SAVED_MEMBER_ID))
+                .andExpect(jsonPath("$.nickname").value(kakaoProfileResponse.getKakaoAccount().getNickname()))
+                .andExpect(jsonPath("$.token.accessToken").value("accessToken"))
+                .andExpect(jsonPath("$.token.refreshToken").value("refreshToken"));
+    }
+}

--- a/src/test/java/com/hyun/udong/auth/presentation/controller/AuthControllerTest.java
+++ b/src/test/java/com/hyun/udong/auth/presentation/controller/AuthControllerTest.java
@@ -15,8 +15,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.Date;
-
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -65,7 +63,7 @@ class AuthControllerTest {
     void refreshTokens() throws Exception {
         // given
         Member member = memberService.save(new Member(100L, SocialType.KAKAO, "hyun", "profile_image"));
-        String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId(), new Date(System.currentTimeMillis() - 1000));
+        String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId());
 
         member.updateRefreshToken(refreshToken);
         memberService.save(member);
@@ -78,5 +76,6 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.nickname").value(member.getNickname()))
                 .andExpect(jsonPath("$.token.accessToken").exists())
                 .andExpect(jsonPath("$.token.refreshToken").exists());
+
     }
 }

--- a/src/test/java/com/hyun/udong/auth/util/JwtTokenProviderTest.java
+++ b/src/test/java/com/hyun/udong/auth/util/JwtTokenProviderTest.java
@@ -28,7 +28,7 @@ class JwtTokenProviderTest {
     @DisplayName("유효한 ID로 액세스 토큰을 생성하면 토큰을 반환한다.")
     void generateAccessToken_validId_returnsToken() {
         Long id = 1L;
-        String token = jwtTokenProvider.generateAccessToken(id, new Date());
+        String token = jwtTokenProvider.generateAccessToken(id);
         assertNotNull(token);
     }
 
@@ -36,7 +36,7 @@ class JwtTokenProviderTest {
     @DisplayName("유효한 ID로 리프레시 토큰을 생성하면 토큰을 반환한다.")
     void generateRefreshToken_validId_returnsToken() {
         Long id = 1L;
-        String token = jwtTokenProvider.generateRefreshToken(id, new Date());
+        String token = jwtTokenProvider.generateRefreshToken(id);
         assertNotNull(token);
     }
 
@@ -44,7 +44,7 @@ class JwtTokenProviderTest {
     @DisplayName("유효한 토큰에서 회원 ID를 추출하면 ID를 반환한다.")
     void getSubject() {
         Long id = 1L;
-        String token = jwtTokenProvider.generateAccessToken(id, new Date());
+        String token = jwtTokenProvider.generateAccessToken(id);
         String memberId = jwtTokenProvider.getSubjectFromToken(token);
         assertEquals(id.toString(), memberId);
     }
@@ -74,8 +74,8 @@ class JwtTokenProviderTest {
     void validateTokenExpiryTimes() {
         // given
         Long memberId = 1L;
-        String accessToken = jwtTokenProvider.generateAccessToken(memberId, new Date());
-        String refreshToken = jwtTokenProvider.generateRefreshToken(memberId, new Date());
+        String accessToken = jwtTokenProvider.generateAccessToken(memberId);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(memberId);
 
         // when
         LocalDateTime accessTokenExpireTime = jwtTokenProvider.getTokenExpireTime(accessToken);

--- a/src/test/java/com/hyun/udong/auth/util/JwtTokenProviderTest.java
+++ b/src/test/java/com/hyun/udong/auth/util/JwtTokenProviderTest.java
@@ -1,0 +1,58 @@
+package com.hyun.udong.auth.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class JwtTokenProviderTest {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("유효한 ID로 액세스 토큰을 생성하면 토큰을 반환한다.")
+    void generateAccessToken_validId_returnsToken() {
+        Long id = 1L;
+        String token = jwtTokenProvider.generateAccessToken(id);
+        assertNotNull(token);
+    }
+
+    @Test
+    @DisplayName("유효한 ID로 리프레시 토큰을 생성하면 토큰을 반환한다.")
+    void generateRefreshToken_validId_returnsToken() {
+        Long id = 1L;
+        String token = jwtTokenProvider.generateRefreshToken(id);
+        assertNotNull(token);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰을 검증하면 false를 반환한다.")
+    void parseToken_invalidToken_returnsFalse() {
+        String token = "invalid.token";
+        assertThrows(Exception.class, () -> jwtTokenProvider.parseToken(token));
+    }
+
+    @Test
+    @DisplayName("유효한 토큰에서 회원 ID를 추출하면 ID를 반환한다.")
+    void getMemberIdFromToken_validToken_returnsId() {
+        Long id = 1L;
+        String token = jwtTokenProvider.generateAccessToken(id);
+        String memberId = jwtTokenProvider.getMemberIdFromToken(token);
+        assertEquals(id.toString(), memberId);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰에서 회원 ID를 추출하면 예외를 던진다.")
+    void getMemberIdFromToken_invalidToken_throwsException() {
+        String token = "invalid.token";
+        assertThrows(Exception.class, () -> jwtTokenProvider.getMemberIdFromToken(token));
+    }
+}

--- a/src/test/java/com/hyun/udong/auth/util/JwtTokenProviderTest.java
+++ b/src/test/java/com/hyun/udong/auth/util/JwtTokenProviderTest.java
@@ -42,18 +42,18 @@ class JwtTokenProviderTest {
 
     @Test
     @DisplayName("유효한 토큰에서 회원 ID를 추출하면 ID를 반환한다.")
-    void getMemberIdFromToken_validToken_returnsId() {
+    void getSubject() {
         Long id = 1L;
         String token = jwtTokenProvider.generateAccessToken(id);
-        String memberId = jwtTokenProvider.getMemberIdFromToken(token);
+        String memberId = jwtTokenProvider.getSubjectFromToken(token);
         assertEquals(id.toString(), memberId);
     }
 
     @Test
     @DisplayName("유효하지 않은 토큰에서 회원 ID를 추출하면 예외를 던진다.")
-    void getMemberIdFromToken_invalidToken_throwsException() {
+    void getSubjectFromToken_invalidToken_throwsException() {
         String token = "invalid.token";
-        assertThrows(Exception.class, () -> jwtTokenProvider.getMemberIdFromToken(token));
+        assertThrows(Exception.class, () -> jwtTokenProvider.getSubjectFromToken(token));
     }
 
     @Test
@@ -66,7 +66,7 @@ class JwtTokenProviderTest {
                 .signWith(Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8)))
                 .compact();
 
-        assertThrows(ExpiredTokenException.class, () -> jwtTokenProvider.getMemberIdFromToken(expiredToken));
+        assertThrows(ExpiredTokenException.class, () -> jwtTokenProvider.getSubjectFromToken(expiredToken));
     }
 
     @Test

--- a/src/test/java/com/hyun/udong/auth/util/JwtTokenProviderTest.java
+++ b/src/test/java/com/hyun/udong/auth/util/JwtTokenProviderTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -67,4 +68,23 @@ class JwtTokenProviderTest {
 
         assertThrows(ExpiredTokenException.class, () -> jwtTokenProvider.getMemberIdFromToken(expiredToken));
     }
+
+    @Test
+    @DisplayName("액세스 토큰과 리프레시 토큰의 만료 시간(1시간 뒤, 2주 뒤)을 검증한다.")
+    void validateTokenExpiryTimes() {
+        // given
+        Long memberId = 1L;
+        String accessToken = jwtTokenProvider.generateAccessToken(memberId);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(memberId);
+
+        // when
+        LocalDateTime accessTokenExpireTime = jwtTokenProvider.getTokenExpireTime(accessToken);
+        LocalDateTime refreshTokenExpireTime = jwtTokenProvider.getTokenExpireTime(refreshToken);
+
+        // then
+        LocalDateTime now = LocalDateTime.now();
+        assertEquals(now.plusHours(1).withNano(0), accessTokenExpireTime.withNano(0));
+        assertEquals(now.plusDays(14).withNano(0), refreshTokenExpireTime.withNano(0));
+    }
+
 }

--- a/src/test/java/com/hyun/udong/auth/util/JwtTokenProviderTest.java
+++ b/src/test/java/com/hyun/udong/auth/util/JwtTokenProviderTest.java
@@ -28,7 +28,7 @@ class JwtTokenProviderTest {
     @DisplayName("유효한 ID로 액세스 토큰을 생성하면 토큰을 반환한다.")
     void generateAccessToken_validId_returnsToken() {
         Long id = 1L;
-        String token = jwtTokenProvider.generateAccessToken(id);
+        String token = jwtTokenProvider.generateAccessToken(id, new Date());
         assertNotNull(token);
     }
 
@@ -36,7 +36,7 @@ class JwtTokenProviderTest {
     @DisplayName("유효한 ID로 리프레시 토큰을 생성하면 토큰을 반환한다.")
     void generateRefreshToken_validId_returnsToken() {
         Long id = 1L;
-        String token = jwtTokenProvider.generateRefreshToken(id);
+        String token = jwtTokenProvider.generateRefreshToken(id, new Date());
         assertNotNull(token);
     }
 
@@ -44,7 +44,7 @@ class JwtTokenProviderTest {
     @DisplayName("유효한 토큰에서 회원 ID를 추출하면 ID를 반환한다.")
     void getSubject() {
         Long id = 1L;
-        String token = jwtTokenProvider.generateAccessToken(id);
+        String token = jwtTokenProvider.generateAccessToken(id, new Date());
         String memberId = jwtTokenProvider.getSubjectFromToken(token);
         assertEquals(id.toString(), memberId);
     }
@@ -74,8 +74,8 @@ class JwtTokenProviderTest {
     void validateTokenExpiryTimes() {
         // given
         Long memberId = 1L;
-        String accessToken = jwtTokenProvider.generateAccessToken(memberId);
-        String refreshToken = jwtTokenProvider.generateRefreshToken(memberId);
+        String accessToken = jwtTokenProvider.generateAccessToken(memberId, new Date());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(memberId, new Date());
 
         // when
         LocalDateTime accessTokenExpireTime = jwtTokenProvider.getTokenExpireTime(accessToken);

--- a/src/test/java/com/hyun/udong/member/application/service/MemberServiceTest.java
+++ b/src/test/java/com/hyun/udong/member/application/service/MemberServiceTest.java
@@ -12,8 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
@@ -68,5 +67,14 @@ class MemberServiceTest {
     @DisplayName("없는 refresh token으로 사용자 정보를 조회했을 때 예외를 발생시킨다.")
     void findByRefreshTokenWithNotExists() {
         assertThrows(MemberNotFoundException.class, () -> memberService.findByRefreshToken(""));
+    }
+
+    @Test
+    @DisplayName("refresh token을 수정한다.")
+    void updateRefreshToken() {
+        Member member = memberService.save2(new Member(3L, SocialType.KAKAO, "신영만", "https://user3.com"));
+        Member updatedMember = memberService.updateRefreshToken(member.getId(), "refreshToken");
+
+        assertEquals("refreshToken", updatedMember.getRefreshToken());
     }
 }

--- a/src/test/java/com/hyun/udong/member/application/service/MemberServiceTest.java
+++ b/src/test/java/com/hyun/udong/member/application/service/MemberServiceTest.java
@@ -3,7 +3,6 @@ package com.hyun.udong.member.application.service;
 import com.hyun.udong.member.domain.Member;
 import com.hyun.udong.member.domain.SocialType;
 import com.hyun.udong.member.exception.MemberNotFoundException;
-import com.hyun.udong.member.presentation.dto.MemberResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,13 +31,12 @@ class MemberServiceTest {
     void saveMember() {
         Member member = new Member(3L, SocialType.KAKAO, "신영만", "https://user3.com");
 
-        MemberResponse savedMember = memberService.save(member);
+        Member savedMember = memberService.save(member);
 
-        MemberResponse findMember = memberService.getMemberById(savedMember.getId());
         assertAll(
-                () -> assertThat(findMember.getId()).isEqualTo(savedMember.getId()),
-                () -> assertThat(findMember.getNickname()).isEqualTo("신영만"),
-                () -> assertThat(findMember.getProfileImageUrl()).isEqualTo("https://user3.com")
+                () -> assertThat(member.getSocialId()).isEqualTo(savedMember.getSocialId()),
+                () -> assertThat(member.getNickname()).isEqualTo("신영만"),
+                () -> assertThat(member.getProfileImageUrl()).isEqualTo("https://user3.com")
         );
     }
 
@@ -47,32 +45,25 @@ class MemberServiceTest {
     void updateMember() {
         Member member = new Member(2L, SocialType.KAKAO, "짱아", "https://user2.com");
 
-        MemberResponse updatedMember = memberService.save(member);
+        Member savedMember = memberService.save(member);
 
-        MemberResponse findMember = memberService.getMemberById(updatedMember.getId());
         assertAll(
-                () -> assertThat(findMember.getId()).isEqualTo(updatedMember.getId()),
-                () -> assertThat(findMember.getNickname()).isEqualTo(updatedMember.getNickname()),
-                () -> assertThat(findMember.getProfileImageUrl()).isEqualTo(updatedMember.getProfileImageUrl())
+                () -> assertThat(member.getSocialId()).isEqualTo(savedMember.getSocialId()),
+                () -> assertThat(member.getNickname()).isEqualTo(savedMember.getNickname()),
+                () -> assertThat(member.getProfileImageUrl()).isEqualTo(savedMember.getProfileImageUrl())
         );
     }
 
     @Test
     @DisplayName("id로 사용자 정보를 조회했을 때 없는 사용자일 경우 예외를 발생시킨다.")
     void getMemberByIdWithNotExists() {
-        assertThrows(MemberNotFoundException.class, () -> memberService.getMemberById(100L));
-    }
-
-    @Test
-    @DisplayName("없는 refresh token으로 사용자 정보를 조회했을 때 예외를 발생시킨다.")
-    void findByRefreshTokenWithNotExists() {
-        assertThrows(MemberNotFoundException.class, () -> memberService.findByRefreshToken(""));
+        assertThrows(MemberNotFoundException.class, () -> memberService.findById(100L));
     }
 
     @Test
     @DisplayName("refresh token을 수정한다.")
     void updateRefreshToken() {
-        Member member = memberService.save2(new Member(3L, SocialType.KAKAO, "신영만", "https://user3.com"));
+        Member member = memberService.save(new Member(3L, SocialType.KAKAO, "신영만", "https://user3.com"));
         Member updatedMember = memberService.updateRefreshToken(member.getId(), "refreshToken");
 
         assertEquals("refreshToken", updatedMember.getRefreshToken());

--- a/src/test/java/com/hyun/udong/member/application/service/MemberServiceTest.java
+++ b/src/test/java/com/hyun/udong/member/application/service/MemberServiceTest.java
@@ -11,7 +11,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
@@ -58,14 +59,5 @@ class MemberServiceTest {
     @DisplayName("id로 사용자 정보를 조회했을 때 없는 사용자일 경우 예외를 발생시킨다.")
     void getMemberByIdWithNotExists() {
         assertThrows(MemberNotFoundException.class, () -> memberService.findById(100L));
-    }
-
-    @Test
-    @DisplayName("refresh token을 수정한다.")
-    void updateRefreshToken() {
-        Member member = memberService.save(new Member(3L, SocialType.KAKAO, "신영만", "https://user3.com"));
-        Member updatedMember = memberService.updateRefreshToken(member.getId(), "refreshToken");
-
-        assertEquals("refreshToken", updatedMember.getRefreshToken());
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -21,6 +21,6 @@ social:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-expire-time: ${ACCESS_TOKEN_EXPIRE_TIME}  # 1시간 (밀리초)
-  refresh-token-expire-time: ${REFRESH_TOKEN_EXPIRE_TIME}  # 14일 (밀리초)
+  access-token-expire-time: ${ACCESS_TOKEN_EXPIRE_TIME}
+  refresh-token-expire-time: ${REFRESH_TOKEN_EXPIRE_TIME}
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -21,3 +21,6 @@ social:
 
 jwt:
   secret: ${JWT_SECRET}
+  access-token-expire-time: ${ACCESS_TOKEN_EXPIRE_TIME}  # 1시간 (밀리초)
+  refresh-token-expire-time: ${REFRESH_TOKEN_EXPIRE_TIME}  # 14일 (밀리초)
+

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,3 +18,6 @@ social:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
     redirect-uri: ${GOOGLE_REDIRECT_URI}
+
+jwt:
+  secret: ${JWT_SECRET}


### PR DESCRIPTION
## #️⃣ Issue
- close #8


## 🧑🏻‍🏫 메인 리뷰어 지정
- 메인 리뷰어 : @blue000927 


## 📝 요약
<!--- 변경 사항에 대한 간략한 요약을 작성해주세요. -->
기존에 세션 대신 idToken을 사용하려 했으나 자체 토큰 발급으로 변경


## 🛠 작업 내용
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1. 카카오에서 제공하는 idToken부분 관련 로직을 제거하고 자체적으로 accessToken&refreshToken을 발급하는 로직을 추가했습니다.
2. 카카오 api를 추가로 사용하지 않을 것 같아 refreshToken도 자체적으로 발급하고 내부에서 관리함으로써 카카오 서버는 로그인 시에만 통신합니다.
3. refreshToken으로 토큰들을 갱신하는 코드를 추가했습니다. 갱신된 refresh_token은 변경 감지로 저장합니다.

## References
<!--- 사용된 레퍼런스에 대한 링크를 남겨주세요. -->
[참고 블로그](https://velog.io/@jiwoow00/Spring-boot-JWT-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EB%B0%B1%EC%97%94%EB%93%9C-%EC%B9%B4%EC%B9%B4%EC%98%A4-%EB%A1%9C%EA%B7%B8%EC%9D%B8)
[참고 repo](https://github.com/Gosrock/DuDoong-Backend)

## 🤔 리뷰 시 참고 사항
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
1. 전체적으로 헷갈리는 부분이 많아 1차적으로 리뷰 받고자 PR 올립니다..!
2. `MemberService.save()`메서드의 동작과 네이밍이 애매한 것 같기도 합니다..(save인데 기존회원이면 반환?)
3. `AuthService`와 `MemberService`의 역할 분배가 잘 된건지 모르겠습니다. (테스트할 때 애매했어요,,)
4. 지금 `AuthContoller`의 메서드들은 단순히 `AuthService`의 메서드를 호출하는 로직밖에 없는데 컨트롤러와 서비스에서 테스트를 어떻게 다르게 하는지 모르겠어요
5. `KakaoOAuthClient`도 테스트 코드 작성하나요??


## ✅ 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] PR을 연관되는 github issue에 연결했습니다.
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트 코드가 필요없는 이유가 있습니다.
