### PR TITLE
[#6] 카카오 로그인 로직 HTTP 클라이언트 변경

### DIFF
--- a/src/main/java/com/hyun/udong/auth/infrastructure/client/KakaoOAuthClient.java
+++ b/src/main/java/com/hyun/udong/auth/infrastructure/client/KakaoOAuthClient.java
@@ -3,11 +3,12 @@ package com.hyun.udong.auth.infrastructure.client;
 import com.hyun.udong.auth.presentation.dto.KakaoProfileResponse;
 import com.hyun.udong.auth.presentation.dto.KakaoTokenResponse;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClient;
 
 @Component
 public class KakaoOAuthClient {
@@ -21,39 +22,34 @@ public class KakaoOAuthClient {
     @Value("${social.kakao.redirect-uri}")
     private String redirectUri;
 
+    private final RestClient restClient;
+
+    public KakaoOAuthClient() {
+        restClient = RestClient.builder()
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
     public KakaoProfileResponse getUserProfile(String accessToken) {
-        RestTemplate restTemplate = new RestTemplate();
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-
-        HttpEntity<Void> request = new HttpEntity<>(headers);
-        ResponseEntity<KakaoProfileResponse> response = restTemplate.exchange(
-                USER_PROFILE_URL, HttpMethod.GET, request, KakaoProfileResponse.class
-        );
-
-        return response.getBody();
+        return restClient.get()
+                .uri(USER_PROFILE_URL)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .body(KakaoProfileResponse.class);
     }
 
     public KakaoTokenResponse getToken(String code) {
-        RestTemplate restTemplate = new RestTemplate();
+        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+        requestBody.add("grant_type", "authorization_code");
+        requestBody.add("client_id", clientId);
+        requestBody.add("redirect_uri", redirectUri);
+        requestBody.add("code", code);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
-
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", clientId);
-        params.add("redirect_uri", redirectUri);
-        params.add("code", code);
-
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
-        ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
-                ACCESS_TOKEN_URL, HttpMethod.POST, request, KakaoTokenResponse.class
-        );
-
-        return response.getBody();
+        return restClient.post()
+                .uri(ACCESS_TOKEN_URL)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .body(requestBody)
+                .retrieve()
+                .body(KakaoTokenResponse.class);
     }
 }


### PR DESCRIPTION
## #️⃣ Issue
- #6 


## 🧑🏻‍🏫 메인 리뷰어 지정
- 메인 리뷰어 : @blue000927 

## 📝 요약
<!--- 변경 사항에 대한 간략한 요약을 작성해주세요. -->
카카오 로그인 관련 http 클라이언트를 RestClient로 변경했습니다.

## 🛠 작업 내용
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
찾아보니 처음에는 **RestTemplate이 deprecated될 것이며, WebClient로 대체된다**는 발표가 있었지만 이후에 해당 주석은 제거되었고 WebClient의 단점을 보완해 RestClient를 권장한다고 합니다.
이에 WebClient, RestClient, OkHttpClient 중에 RestClient로 변경했습니다.

## References
<!--- 사용된 레퍼런스에 대한 링크를 남겨주세요. -->
- [관련 TIL 작성](https://github.com/hynxp/TIL/blob/main/Spaces/Home/Spring/%EC%A0%95%EB%A6%AC%EB%85%B8%ED%8A%B8/RestTemplate%20vs%20WebClient%20vs%20RestClient.md)

## ✅ 체크리스트
- [x] PR 제목을 명령형으로 작성했습니다.
- [x] PR을 연관되는 github issue에 연결했습니다.
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트 코드가 필요없는 이유가 있습니다.
