### PR TITLE
refresh-token Redis 저장 및 블랙리스트 기법 적용

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,15 @@ logs-k6:
 
 restart-spring:
 	docker compose -f $(PROJECT_COMPOSE) restart spring
+
+start-redis:
+	docker compose -f $(PROJECT_COMPOSE) up -d redis
+
+stop-redis:
+	docker compose -f $(PROJECT_COMPOSE) stop redis
+
+logs-redis:
+	docker compose -f $(PROJECT_COMPOSE) logs -f redis
+
+restart-redis:
+	docker compose -f $(PROJECT_COMPOSE) restart redis

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -34,4 +34,6 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.retry:spring-retry'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }

--- a/backend/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
+++ b/backend/src/main/java/com/hyun/udong/auth/application/service/AuthService.java
@@ -1,5 +1,10 @@
 package com.hyun.udong.auth.application.service;
 
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.hyun.udong.auth.exception.InvalidTokenException;
 import com.hyun.udong.auth.infrastructure.client.KakaoOAuthClient;
 import com.hyun.udong.auth.presentation.dto.AuthTokens;
@@ -12,10 +17,8 @@ import com.hyun.udong.member.application.service.MemberService;
 import com.hyun.udong.member.domain.Member;
 import com.hyun.udong.member.domain.SocialType;
 import com.hyun.udong.member.infrastructure.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional(readOnly = true)
@@ -26,6 +29,7 @@ public class AuthService {
     private final MemberService memberService;
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     @Transactional
     public LoginResponse kakaoLogin(String code) {
@@ -37,7 +41,8 @@ public class AuthService {
 
         String accessToken = jwtTokenProvider.generateAccessToken(member.getId());
         String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId());
-        updateRefreshToken(member.getId(), refreshToken);
+        LocalDateTime refreshTokenExpireTime = jwtTokenProvider.getTokenExpireTime(refreshToken);
+        refreshTokenService.save(refreshToken, member.getId().toString(), refreshTokenExpireTime);
 
         AuthTokens authTokens = new AuthTokens(accessToken, jwtTokenProvider.getTokenExpireTime(accessToken), refreshToken, jwtTokenProvider.getTokenExpireTime(refreshToken));
         return new LoginResponse(member.getId(), member.getNickname(), authTokens);
@@ -45,16 +50,24 @@ public class AuthService {
 
     @Transactional
     public LoginResponse refreshTokens(String refreshToken) {
+        if (!refreshTokenService.isValid(refreshToken)) {
+            throw InvalidTokenException.EXCEPTION;
+        }
         Long memberId = extractMemberId(refreshToken);
 
-        validateIsTokenOwner(refreshToken, memberId);
+        // 기존 토큰 삭제
+        refreshTokenService.delete(refreshToken);
 
+        // 새 토큰 발급 및 저장
         String newAccessToken = jwtTokenProvider.generateAccessToken(memberId);
         String newRefreshToken = jwtTokenProvider.generateRefreshToken(memberId);
+        LocalDateTime newRefreshTokenExpireTime = jwtTokenProvider.getTokenExpireTime(newRefreshToken);
+        refreshTokenService.save(newRefreshToken, memberId.toString(), newRefreshTokenExpireTime);
 
-        Member member = updateRefreshToken(memberId, newRefreshToken);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException("해당하는 회원이 존재하지 않습니다."));
 
-        AuthTokens authTokens = new AuthTokens(newAccessToken, jwtTokenProvider.getTokenExpireTime(newAccessToken), newRefreshToken, jwtTokenProvider.getTokenExpireTime(newRefreshToken));
+        AuthTokens authTokens = new AuthTokens(newAccessToken, jwtTokenProvider.getTokenExpireTime(newAccessToken), newRefreshToken, newRefreshTokenExpireTime);
         return new LoginResponse(member.getId(), member.getNickname(), authTokens);
     }
 
@@ -68,26 +81,13 @@ public class AuthService {
         return memberId;
     }
 
-    private void validateIsTokenOwner(String refreshToken, Long memberId) {
-        Long ownerId = memberRepository.findByRefreshToken(refreshToken)
-                .orElseThrow(() -> InvalidTokenException.EXCEPTION)
-                .getId();
-
-        if (!ownerId.equals(memberId)) {
-            throw InvalidTokenException.EXCEPTION;
-        }
-    }
-
-    private Member updateRefreshToken(Long memberId, String refreshToken) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundException("해당하는 회원이 존재하지 않습니다."));
-        member.updateRefreshToken(refreshToken);
-        return member;
-    }
-
     public Member findMemberFromToken(String token) {
         Long memberId = Long.parseLong(jwtTokenProvider.getSubjectFromToken(token));
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> InvalidTokenException.EXCEPTION);
+    }
+
+    public void logout(String refreshToken) {
+        refreshTokenService.delete(refreshToken);
     }
 }

--- a/backend/src/main/java/com/hyun/udong/auth/application/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/hyun/udong/auth/application/service/RefreshTokenService.java
@@ -27,7 +27,7 @@ public class RefreshTokenService {
     }
 
     public boolean isValid(String refreshToken) {
-        return redisTemplate.hasKey(refreshToken);
+        return Boolean.TRUE.equals(redisTemplate.hasKey(refreshToken));
     }
 
     public String getUserId(String refreshToken) {
@@ -41,6 +41,6 @@ public class RefreshTokenService {
 
     public boolean isBlacklisted(String refreshToken) {
         String blacklistKey = "blacklist:" + refreshToken;
-        return redisTemplate.hasKey(blacklistKey);
+        return Boolean.TRUE.equals(redisTemplate.hasKey(blacklistKey));
     }
 }

--- a/backend/src/main/java/com/hyun/udong/auth/application/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/hyun/udong/auth/application/service/RefreshTokenService.java
@@ -27,10 +27,20 @@ public class RefreshTokenService {
     }
 
     public boolean isValid(String refreshToken) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(refreshToken));
+        return redisTemplate.hasKey(refreshToken);
     }
 
     public String getUserId(String refreshToken) {
         return redisTemplate.opsForValue().get(refreshToken);
     }
-} 
+
+    public void addToBlacklist(String refreshToken, long ttlMillis) {
+        String blacklistKey = "blacklist:" + refreshToken;
+        redisTemplate.opsForValue().set(blacklistKey, "logout", ttlMillis, TimeUnit.MILLISECONDS);
+    }
+
+    public boolean isBlacklisted(String refreshToken) {
+        String blacklistKey = "blacklist:" + refreshToken;
+        return redisTemplate.hasKey(blacklistKey);
+    }
+}

--- a/backend/src/main/java/com/hyun/udong/auth/application/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/hyun/udong/auth/application/service/RefreshTokenService.java
@@ -1,0 +1,36 @@
+package com.hyun.udong.auth.application.service;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class RefreshTokenService {
+    private final StringRedisTemplate redisTemplate;
+
+    public RefreshTokenService(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void save(String refreshToken, String userId, LocalDateTime expiresAt) {
+        long ttlMillis = Duration.between(LocalDateTime.now(), expiresAt).toMillis();
+        if (ttlMillis > 0) {
+            redisTemplate.opsForValue().set(refreshToken, userId, ttlMillis, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    public void delete(String refreshToken) {
+        redisTemplate.delete(refreshToken);
+    }
+
+    public boolean isValid(String refreshToken) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(refreshToken));
+    }
+
+    public String getUserId(String refreshToken) {
+        return redisTemplate.opsForValue().get(refreshToken);
+    }
+} 

--- a/backend/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
+++ b/backend/src/main/java/com/hyun/udong/auth/presentation/controller/AuthController.java
@@ -4,10 +4,7 @@ import com.hyun.udong.auth.application.service.AuthService;
 import com.hyun.udong.auth.presentation.dto.LoginResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,5 +23,11 @@ public class AuthController {
     public ResponseEntity<LoginResponse> refreshTokens(@RequestParam("refreshToken") final String refreshToken) {
         LoginResponse loginResponse = authService.refreshTokens(refreshToken);
         return ResponseEntity.ok().body(loginResponse);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestParam("refreshToken") final String refreshToken) {
+        authService.logout(refreshToken);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/hyun/udong/member/domain/Member.java
+++ b/backend/src/main/java/com/hyun/udong/member/domain/Member.java
@@ -1,12 +1,23 @@
 package com.hyun.udong.member.domain;
 
+import static lombok.AccessLevel.PROTECTED;
+
 import com.hyun.udong.common.entity.BaseTimeEntity;
 import com.hyun.udong.travelschedule.domain.TravelSchedule;
-import jakarta.persistence.*;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
@@ -31,8 +42,6 @@ public class Member extends BaseTimeEntity {
 
     private String profileImageUrl;
 
-    private String refreshToken;
-
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JoinColumn(name = "travel_schedule_id")
     private TravelSchedule travelSchedule;
@@ -42,10 +51,6 @@ public class Member extends BaseTimeEntity {
         this.socialType = socialType;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
-    }
-
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
     }
 
     public void updateTravelSchedule(TravelSchedule travelSchedule) {

--- a/backend/src/main/java/com/hyun/udong/member/infrastructure/repository/MemberRepository.java
+++ b/backend/src/main/java/com/hyun/udong/member/infrastructure/repository/MemberRepository.java
@@ -1,15 +1,14 @@
 package com.hyun.udong.member.infrastructure.repository;
 
-import com.hyun.udong.member.domain.Member;
-import com.hyun.udong.member.domain.SocialType;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import com.hyun.udong.member.domain.Member;
+import com.hyun.udong.member.domain.SocialType;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findBySocialIdAndSocialType(Long socialId, SocialType socialType);
-
-    Optional<Member> findByRefreshToken(String refreshToken);
 }
 

--- a/backend/src/main/java/com/hyun/udong/udong/domain/Udong.java
+++ b/backend/src/main/java/com/hyun/udong/udong/domain/Udong.java
@@ -1,18 +1,29 @@
 package com.hyun.udong.udong.domain;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 import com.hyun.udong.common.entity.BaseTimeEntity;
 import com.hyun.udong.common.exception.InvalidParameterException;
 import com.hyun.udong.travelschedule.domain.City;
 import com.hyun.udong.udong.exception.InvalidParticipationException;
-import jakarta.persistence.*;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 
 @Entity

--- a/backend/src/main/java/com/hyun/udong/udong/domain/WaitingMember.java
+++ b/backend/src/main/java/com/hyun/udong/udong/domain/WaitingMember.java
@@ -1,14 +1,23 @@
 package com.hyun.udong.udong.domain;
 
-import jakarta.persistence.*;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-
-import static lombok.AccessLevel.PROTECTED;
-
+@Table(name = "waiting_members")
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,10 +5,10 @@ spring:
   config:
     import: optional:file:.env[.properties],optional:file:.env.${spring.profiles.active}[.properties]
 
-  datasource:
-    url: ${DATASOURCE_URL}
-    username: ${DATASOURCE_USERNAME}
-    password: ${DATASOURCE_PASSWORD}
+  # datasource:
+  #   url: ${DATASOURCE_URL}
+  #   username: ${DATASOURCE_USERNAME}
+  #   password: ${DATASOURCE_PASSWORD}
 
   application:
     name: udong

--- a/backend/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
@@ -1,18 +1,6 @@
 package com.hyun.udong.auth.application.service;
 
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.mockito.BDDMockito.given;
-
-import java.time.LocalDateTime;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-
+import com.hyun.udong.auth.exception.InvalidTokenException;
 import com.hyun.udong.auth.infrastructure.client.KakaoOAuthClient;
 import com.hyun.udong.auth.presentation.dto.KakaoProfileResponse;
 import com.hyun.udong.auth.presentation.dto.KakaoTokenResponse;
@@ -22,6 +10,19 @@ import com.hyun.udong.common.util.DataCleanerExtension;
 import com.hyun.udong.member.application.service.MemberService;
 import com.hyun.udong.member.domain.Member;
 import com.hyun.udong.member.domain.SocialType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(DataCleanerExtension.class)
 @SpringBootTest
@@ -84,7 +85,7 @@ class AuthServiceTest {
         // given
         String oldRefreshToken = "oldRefreshToken";
         String newRefreshToken = "newRefreshToken";
-        
+
         Member member = memberService.save(new Member(100L, SocialType.KAKAO, "hyun", "profile_image"));
         Long memberId = member.getId();
         refreshTokenService.save(oldRefreshToken, memberId.toString(), LocalDateTime.now().plusMinutes(10));
@@ -102,6 +103,59 @@ class AuthServiceTest {
         // 새 토큰은 저장됨
         String redisValue = redisTemplate.opsForValue().get(newRefreshToken);
         then(redisValue).isEqualTo(memberId.toString());
+    }
+
+    @Test
+    void refreshToken_재발급_시_기존_토큰이_블랙리스트에_등록된다() {
+        // given
+        String oldRefreshToken = "oldRefreshToken2";
+        String newRefreshToken = "newRefreshToken2";
+        Member member = memberService.save(new Member(300L, SocialType.KAKAO, "hyun2", "profile_image2"));
+        Long memberId = member.getId();
+        refreshTokenService.save(oldRefreshToken, memberId.toString(), LocalDateTime.now().plusMinutes(10));
+        given(jwtTokenProvider.getSubjectFromToken(oldRefreshToken)).willReturn(memberId.toString());
+        given(jwtTokenProvider.generateAccessToken(memberId)).willReturn("accessToken2");
+        given(jwtTokenProvider.generateRefreshToken(memberId)).willReturn(newRefreshToken);
+        given(jwtTokenProvider.getTokenExpireTime(newRefreshToken)).willReturn(LocalDateTime.now().plusMinutes(10));
+        given(jwtTokenProvider.getTokenExpireTime(oldRefreshToken)).willReturn(LocalDateTime.now().plusMinutes(10));
+
+        // when
+        authService.refreshTokens(oldRefreshToken);
+
+        // then
+        then(refreshTokenService.isBlacklisted(oldRefreshToken)).isTrue();
+    }
+
+    @Test
+    void 블랙리스트에_등록된_refreshToken으로_재발급_요청시_예외가_발생한다() {
+        // given
+        String blacklistedToken = "blacklistedToken";
+        Long memberId = 400L;
+        refreshTokenService.save(blacklistedToken, memberId.toString(), LocalDateTime.now().plusMinutes(10));
+        given(jwtTokenProvider.getSubjectFromToken(blacklistedToken)).willReturn(memberId.toString());
+        given(jwtTokenProvider.getTokenExpireTime(blacklistedToken)).willReturn(LocalDateTime.now().plusMinutes(10));
+        // 블랙리스트 등록
+        refreshTokenService.addToBlacklist(blacklistedToken, 10 * 60 * 1000);
+
+        // when & then
+        Assertions.assertThrows(InvalidTokenException.class, () -> {
+            authService.refreshTokens(blacklistedToken);
+        });
+    }
+
+    @Test
+    void 로그아웃_시_refreshToken이_블랙리스트에_등록된다() {
+        // given
+        String refreshToken = "logoutToken2";
+        Long memberId = 500L;
+        refreshTokenService.save(refreshToken, memberId.toString(), LocalDateTime.now().plusMinutes(10));
+        given(jwtTokenProvider.getTokenExpireTime(refreshToken)).willReturn(LocalDateTime.now().plusMinutes(10));
+
+        // when
+        authService.logout(refreshToken);
+
+        // then
+        then(refreshTokenService.isBlacklisted(refreshToken)).isTrue();
     }
 
     @Test

--- a/backend/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/hyun/udong/auth/application/service/AuthServiceTest.java
@@ -1,6 +1,18 @@
 package com.hyun.udong.auth.application.service;
 
-import com.hyun.udong.auth.exception.InvalidTokenException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
 import com.hyun.udong.auth.infrastructure.client.KakaoOAuthClient;
 import com.hyun.udong.auth.presentation.dto.KakaoProfileResponse;
 import com.hyun.udong.auth.presentation.dto.KakaoTokenResponse;
@@ -10,16 +22,6 @@ import com.hyun.udong.common.util.DataCleanerExtension;
 import com.hyun.udong.member.application.service.MemberService;
 import com.hyun.udong.member.domain.Member;
 import com.hyun.udong.member.domain.SocialType;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.BDDAssertions.thenThrownBy;
-import static org.mockito.BDDMockito.given;
 
 @ExtendWith(DataCleanerExtension.class)
 @SpringBootTest
@@ -37,8 +39,14 @@ class AuthServiceTest {
     @Autowired
     private AuthService authService;
 
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
     @Test
-    void 카카오_로그인_시_사용자_정보와_refresh_token이_저장된다() {
+    void 카카오_로그인_시_refreshToken이_Redis에_저장된다() {
         // given
         String code = "authCode";
         KakaoTokenResponse kakaoTokenResponse = new KakaoTokenResponse("accessToken");
@@ -48,46 +56,65 @@ class AuthServiceTest {
         given(kakaoOAuthClient.getUserProfile(kakaoTokenResponse.getAccessToken())).willReturn(profile);
         given(jwtTokenProvider.generateAccessToken(1L)).willReturn("accessToken");
         given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("refreshToken");
+        given(jwtTokenProvider.getTokenExpireTime("refreshToken")).willReturn(LocalDateTime.now().plusMinutes(10));
 
         // when
         LoginResponse response = authService.kakaoLogin(code);
 
         // then
-        Member member = memberService.findBySocialIdAndSocialType(profile.getId(), SocialType.KAKAO).orElseThrow();
+        // 1. 응답값 검증
         then(response).isNotNull();
-        then(response.getId()).isEqualTo(member.getId());
-        then(response.getToken().accessToken()).isEqualTo("accessToken");
         then(response.getToken().refreshToken()).isEqualTo("refreshToken");
+        then(response.getId()).isEqualTo(1L);
+
+        // 2. Redis에 저장된 값 검증
+        String redisValue = redisTemplate.opsForValue().get(response.getToken().refreshToken());
+        then(redisValue).isEqualTo(String.valueOf(response.getId()));
+
+        // 3. Redis에 실제로 키가 존재하는지
+        then(redisTemplate.hasKey(response.getToken().refreshToken())).isTrue();
+
+        // 4. TTL(만료 시간) 검증 (예: 9분 이상 남아있는지)
+        Long ttl = redisTemplate.getExpire(response.getToken().refreshToken(), TimeUnit.SECONDS);
+        then(ttl).isGreaterThan(500L); // 10분 중 500초(8분 20초) 이상 남아있으면 정상
     }
 
     @Test
-    @DisplayName(" 재발급 시 새로운 토큰을 저장한다.")
-    void refreshToken_재발급_시_새로운_토큰을_저장한다() {
+    void refreshToken_재발급_시_기존_토큰은_삭제되고_새_토큰이_Redis에_저장된다() {
         // given
-        Member member = memberService.save(new Member(100L, SocialType.KAKAO, "hyun", "profile_image"));
-        String initialRefreshToken = "initialRefreshToken";
-        member.updateRefreshToken(initialRefreshToken);
-        memberService.save(member);
-
+        String oldRefreshToken = "oldRefreshToken";
         String newRefreshToken = "newRefreshToken";
-        given(jwtTokenProvider.generateRefreshToken(member.getId())).willReturn(newRefreshToken);
-        given(jwtTokenProvider.getSubjectFromToken(initialRefreshToken)).willReturn(String.valueOf(member.getId()));
+        
+        Member member = memberService.save(new Member(100L, SocialType.KAKAO, "hyun", "profile_image"));
+        Long memberId = member.getId();
+        refreshTokenService.save(oldRefreshToken, memberId.toString(), LocalDateTime.now().plusMinutes(10));
+        given(jwtTokenProvider.getSubjectFromToken(oldRefreshToken)).willReturn(memberId.toString());
+        given(jwtTokenProvider.generateAccessToken(memberId)).willReturn("accessToken");
+        given(jwtTokenProvider.generateRefreshToken(memberId)).willReturn(newRefreshToken);
+        given(jwtTokenProvider.getTokenExpireTime(newRefreshToken)).willReturn(LocalDateTime.now().plusMinutes(10));
 
         // when
-        authService.refreshTokens(initialRefreshToken);
+        LoginResponse response = authService.refreshTokens(oldRefreshToken);
 
         // then
-        Member updatedMember = memberService.findById(member.getId());
-        then(updatedMember.getRefreshToken()).isNotEqualTo(initialRefreshToken);
-        then(updatedMember.getRefreshToken()).isEqualTo(newRefreshToken);
+        // 기존 토큰은 삭제됨
+        then(redisTemplate.hasKey(oldRefreshToken)).isFalse();
+        // 새 토큰은 저장됨
+        String redisValue = redisTemplate.opsForValue().get(newRefreshToken);
+        then(redisValue).isEqualTo(memberId.toString());
     }
 
     @Test
-    void 토큰_재발급_시_유효한_코드가_아니면_예외가_발생한다() {
-        String otherRefreshToken = jwtTokenProvider.generateRefreshToken(200L);
+    void 로그아웃_시_refreshToken이_Redis에서_삭제된다() {
+        // given
+        String refreshToken = "logoutToken";
+        Long memberId = 200L;
+        refreshTokenService.save(refreshToken, memberId.toString(), LocalDateTime.now().plusMinutes(10));
 
-        // when & then
-        thenThrownBy(() -> authService.refreshTokens(otherRefreshToken))
-                .isInstanceOf(InvalidTokenException.class);
+        // when
+        authService.logout(refreshToken);
+
+        // then
+        then(redisTemplate.hasKey(refreshToken)).isFalse();
     }
 }

--- a/backend/src/test/java/com/hyun/udong/auth/application/service/RefreshTokenServiceTest.java
+++ b/backend/src/test/java/com/hyun/udong/auth/application/service/RefreshTokenServiceTest.java
@@ -1,0 +1,60 @@
+package com.hyun.udong.auth.application.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class RefreshTokenServiceTest {
+
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Test
+    void 저장된_리프레시토큰은_유효하고_삭제하면_무효가_된다() {
+        // given
+        String refreshToken = UUID.randomUUID().toString();
+        String userId = "123";
+        LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(5);
+
+        // when
+        refreshTokenService.save(refreshToken, userId, expiresAt);
+
+        // then
+        assertThat(refreshTokenService.isValid(refreshToken)).isTrue();
+        assertThat(refreshTokenService.getUserId(refreshToken)).isEqualTo(userId);
+
+        // when - 삭제
+        refreshTokenService.delete(refreshToken);
+
+        // then
+        assertThat(refreshTokenService.isValid(refreshToken)).isFalse();
+    }
+
+    @Test
+    void 만료된_리프레시토큰은_유효하지_않다() throws InterruptedException {
+        // given
+        String refreshToken = UUID.randomUUID().toString();
+        String userId = "456";
+        LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(1);
+
+        // when
+        refreshTokenService.save(refreshToken, userId, expiresAt);
+
+        // then
+        assertThat(refreshTokenService.isValid(refreshToken)).isTrue();
+
+        // 1.5초 대기 후 만료 확인
+        Thread.sleep(1500);
+        assertThat(refreshTokenService.isValid(refreshToken)).isFalse();
+    }
+}

--- a/backend/src/test/java/com/hyun/udong/auth/presentation/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/hyun/udong/auth/presentation/controller/AuthControllerTest.java
@@ -1,18 +1,6 @@
 package com.hyun.udong.auth.presentation.controller;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-
+import com.hyun.udong.auth.application.service.RefreshTokenService;
 import com.hyun.udong.auth.infrastructure.client.KakaoOAuthClient;
 import com.hyun.udong.auth.presentation.dto.KakaoProfileResponse;
 import com.hyun.udong.auth.presentation.dto.KakaoTokenResponse;
@@ -21,9 +9,20 @@ import com.hyun.udong.common.util.DataCleanerExtension;
 import com.hyun.udong.member.application.service.MemberService;
 import com.hyun.udong.member.domain.Member;
 import com.hyun.udong.member.domain.SocialType;
-
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(DataCleanerExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -38,6 +37,9 @@ class AuthControllerTest {
 
     @Autowired
     private MemberService memberService;
+
+    @Autowired
+    private RefreshTokenService refreshTokenService;
 
     @LocalServerPort
     private int port;
@@ -92,5 +94,23 @@ class AuthControllerTest {
                 .body("nickname", equalTo(member.getNickname()))
                 .body("token.accessToken", notNullValue())
                 .body("token.refreshToken", notNullValue());
+    }
+
+    @Test
+    void 로그아웃_요청시_204와_블랙리스트_등록이_정상적으로_동작한다() {
+        // given
+        Long memberId = 12345L;
+        String refreshToken = jwtTokenProvider.generateRefreshToken(memberId);
+        refreshTokenService.save(refreshToken, memberId.toString(), jwtTokenProvider.getTokenExpireTime(refreshToken));
+
+        // when & then
+        RestAssured
+                .given().log().all()
+                .contentType(ContentType.JSON)
+                .queryParam("refreshToken", refreshToken)
+                .when()
+                .post("/api/auth/logout")
+                .then().log().all()
+                .statusCode(204);
     }
 }

--- a/backend/src/test/java/com/hyun/udong/auth/presentation/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/hyun/udong/auth/presentation/controller/AuthControllerTest.java
@@ -1,15 +1,10 @@
 package com.hyun.udong.auth.presentation.controller;
 
-import com.hyun.udong.auth.infrastructure.client.KakaoOAuthClient;
-import com.hyun.udong.auth.presentation.dto.KakaoProfileResponse;
-import com.hyun.udong.auth.presentation.dto.KakaoTokenResponse;
-import com.hyun.udong.auth.util.JwtTokenProvider;
-import com.hyun.udong.common.util.DataCleanerExtension;
-import com.hyun.udong.member.application.service.MemberService;
-import com.hyun.udong.member.domain.Member;
-import com.hyun.udong.member.domain.SocialType;
-import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,10 +13,17 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
+import com.hyun.udong.auth.infrastructure.client.KakaoOAuthClient;
+import com.hyun.udong.auth.presentation.dto.KakaoProfileResponse;
+import com.hyun.udong.auth.presentation.dto.KakaoTokenResponse;
+import com.hyun.udong.auth.util.JwtTokenProvider;
+import com.hyun.udong.common.util.DataCleanerExtension;
+import com.hyun.udong.member.application.service.MemberService;
+import com.hyun.udong.member.domain.Member;
+import com.hyun.udong.member.domain.SocialType;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 
 @ExtendWith(DataCleanerExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -74,9 +76,6 @@ class AuthControllerTest {
         // given
         Member member = memberService.save(new Member(100L, SocialType.KAKAO, "hyun", "profile_image"));
         String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId());
-
-        member.updateRefreshToken(refreshToken);
-        memberService.save(member);
 
         // when & then
         RestAssured

--- a/backend/src/test/java/com/hyun/udong/common/util/DataCleaner.java
+++ b/backend/src/test/java/com/hyun/udong/common/util/DataCleaner.java
@@ -1,23 +1,28 @@
 package com.hyun.udong.common.util;
 
-import jakarta.annotation.PostConstruct;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Table;
+import jakarta.persistence.metamodel.EntityType;
+import jakarta.persistence.metamodel.Metamodel;
+import jakarta.persistence.metamodel.SingularAttribute;
 
 @Component
 public class DataCleaner {
 
-    private static final String[] EXCLUDED_TABLES = {"CITY", "COUNTRY",
-            "UDONG_TAGS"};
+    private static final String[] EXCLUDED_TABLES = {"city", "country", "udong_tags"};
     private static final String FIND_TABLES_QUERY = """
                 SELECT table_name 
                 FROM information_schema.tables 
-                WHERE table_schema = 'PUBLIC' 
+                WHERE table_schema = 'public' 
                 AND table_name NOT IN (%s)
             """.formatted(String.join(", ", wrapWithQuotes(EXCLUDED_TABLES)));
     private final List<String> tableNames = new ArrayList<>();
@@ -28,6 +33,7 @@ public class DataCleaner {
     @SuppressWarnings("unchecked")
     @PostConstruct
     public void findDatabaseTableNames() {
+        System.out.println("FIND_TABLES_QUERY: " + FIND_TABLES_QUERY);
         List<Object> tableInfos = entityManager.createNativeQuery(FIND_TABLES_QUERY).getResultList();
         for (Object tableInfo : tableInfos) {
             tableNames.add((String) tableInfo);
@@ -41,16 +47,53 @@ public class DataCleaner {
     }
 
     public void truncate() {
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
-        for (String tableName : tableNames) {
-            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
-            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN " + getIdColumnName(tableName) + " RESTART WITH 1").executeUpdate();
+        String dbProductName = getDatabaseProductName();
+        if (dbProductName.contains("H2")) {
+            entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+            for (String tableName : tableNames) {
+                entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+                entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN " + getIdColumnName(tableName) + " RESTART WITH 1").executeUpdate();
+            }
+            entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+        } else if (dbProductName.contains("PostgreSQL")) {
+            for (String tableName : tableNames) {
+                entityManager.createNativeQuery("TRUNCATE TABLE " + tableName + " CASCADE").executeUpdate();
+                String sequenceName = tableName.toLowerCase() + "_" + getIdColumnName(tableName).toLowerCase() + "_seq";
+                entityManager.createNativeQuery("ALTER SEQUENCE " + sequenceName + " RESTART WITH 1").executeUpdate();
+            }
         }
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+
+    private String getDatabaseProductName() {
+        try {
+            org.hibernate.Session session = entityManager.unwrap(org.hibernate.Session.class);
+            return session.doReturningWork(connection -> connection.getMetaData().getDatabaseProductName());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get database product name", e);
+        }
     }
 
     private String getIdColumnName(String tableName) {
-        return tableName.toUpperCase() + "_ID";
+        Metamodel metamodel = entityManager.getMetamodel();
+        for (EntityType<?> entityType : metamodel.getEntities()) {
+            Table table = entityType.getJavaType().getAnnotation(Table.class);
+            if (table != null && table.name().equalsIgnoreCase(tableName)) {
+                // PK 컬럼명 추출
+                Class<?> idType = entityType.getIdType().getJavaType();
+                SingularAttribute<?, ?> idAttr = entityType.getId(idType);
+                try {
+                    Column column = entityType.getJavaType().getDeclaredField(idAttr.getName()).getAnnotation(Column.class);
+                    if (column != null && !column.name().isEmpty()) {
+                        return column.name();
+                    }
+                } catch (NoSuchFieldException e) {
+                    e.printStackTrace();
+                }
+                return idAttr.getName();
+            }
+        }
+        // 못 찾으면 기본 규칙
+        return tableName.toLowerCase() + "_id";
     }
 
     private static String[] wrapWithQuotes(String[] tables) {

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -19,7 +19,7 @@ spring:
     scripts: classpath:/data.sql
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
 
 social:

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     show-sql: true
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true
@@ -17,6 +17,10 @@ spring:
     init:
       mode: always
     scripts: classpath:/data.sql
+  data:
+    redis:
+      host: redis
+      port: 6379
 
 social:
   kakao:
@@ -31,4 +35,3 @@ jwt:
   secret: udongudongudongudongudongudongudong123
   access-token-expire-time: 123123
   refresh-token-expire-time: 123123
-

--- a/backend/src/test/resources/data.sql
+++ b/backend/src/test/resources/data.sql
@@ -24,7 +24,8 @@ VALUES (1, 'South Korea', 'KR'),
        (22, 'Egypt', 'EG'),
        (23, 'Saudi Arabia', 'SA'),
        (24, 'Vietnam', 'VN'),
-       (25, 'Malaysia', 'MY');
+       (25, 'Malaysia', 'MY')
+ON CONFLICT DO NOTHING;
 
 -- 도시 데이터 삽입
 INSERT INTO city (city_id, name, country_id)
@@ -78,4 +79,5 @@ VALUES (1, 'Seoul', 1),
        (48, 'Hanoi', 24),
        (49, 'Ho Chi Minh City', 24),
        (50, 'Kuala Lumpur', 25),
-       (51, 'Penang', 25);
+       (51, 'Penang', 25)
+ON CONFLICT DO NOTHING;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1.0'
+          cpus: "1.0"
           memory: 1024M
         reservations:
-          cpus: '1.0'
+          cpus: "1.0"
           memory: 1024M
     build:
       context: .
@@ -29,10 +29,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1.0'
+          cpus: "1.0"
           memory: 1024M
         reservations:
-          cpus: '1.0'
+          cpus: "1.0"
           memory: 1024M
     ports:
       - "5433:5432"
@@ -57,5 +57,14 @@ services:
     depends_on:
       - postgres
 
+  redis:
+    image: redis:7
+    container_name: redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
 volumes:
   postgres_data:
+  redis_data:


### PR DESCRIPTION
## 📝 요약
refresh-token에 대해 redis 저장 및 블랙리스트 기법 도입


## 🛠 작업 내용
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- RefreshTokenService를 추가하여 리프레시 토큰의 저장, 삭제, 검증 기능을 구현함
- AuthService에서 로그인 및 토큰 갱신 시 RefreshTokenService를 활용하도록 수정
- Member 엔티티에서 직접 리프레시 토큰을 관리하던 로직 제거
- AuthService 테스트를 보강하여 Redis 연동 및 리프레시 토큰 관리 검증
- MemberRepository에서 사용하지 않는 리프레시 토큰 관련 쿼리 제거
- refresh-token에 대해 블랙리스트 기법 도입
- 로그아웃 엔드포인트 추가

## References
<!--- 사용된 레퍼런스에 대한 링크를 남겨주세요. -->
- [Refresh Token, 블랙 리스트 도입기](https://velog.io/@hyojhand/Refresh-Token-%EB%B8%94%EB%9E%99-%EB%A6%AC%EC%8A%A4%ED%8A%B8-%EB%8F%84%EC%9E%85%EA%B8%B0)
- [Access Token 블랙리스트 관리하기](https://guswls28.tistory.com/148)